### PR TITLE
Re-instate invokables

### DIFF
--- a/doc/book/migration.md
+++ b/doc/book/migration.md
@@ -57,31 +57,10 @@ Configuration for v2 consisted of the following:
 ]
 ```
 
-In v3, the configuration remains roughly the same, with the following changes:
+In v3, the configuration remains the same, with the following additions:
 
 ```php
 [
-    'services' => [
-        // service name => instance pairs
-    ],
-    'aliases' => [
-        // alias => service name pairs
-    ],
-    'factories' => [
-        // service name => factory pairs
-    ],
-    'abstract_factories' => [
-        // abstract factories
-    ],
-    'initializers' => [
-        // initializers
-    ],
-    'delegators' => [
-        // service name => [ delegator factories ]
-    ],
-    'shared' => [
-        // service name => boolean
-    ],
     'lazy_services' => [
         // The class_map is required if using lazy services:
         'class_map' => [
@@ -92,69 +71,29 @@ In v3, the configuration remains roughly the same, with the following changes:
         'proxies_target_dir' => 'path in which to write generated proxy classes',
         'write_proxy_files'  => true, // boolean; false by default
     ],
-    'share_by_default' => boolean,
 ]
 ```
 
-The main changes are that invokables no longer exist, and that lazy service
-configuration is now integrated.
+The main change is the addition of integrated lazy service configuration is now
+integrated.
 
 ### Invokables
 
-*Invokables no longer exist.* As such, that key is no longer relevant. In each
-case, if the service name is also the name of the class, you can use the
-`InvokableFactory` and assign the service as a factory.
+*Invokables no longer exist,* at least, not identically to how they existed in
+ZF2.
 
-As an example, if you previously had the following configuration:
+Internally, `ServiceManager` now does the following for `invokables` entries:
 
-```php
-return [
-    'invokables' => [
-        'MyClass' => 'MyClass',
-    ],
-];
-```
+- If the name and value match, it creates a `factories` entry mapping the
+  service name to `Zend\ServiceManager\Factory\InvokableFactory`.
+- If the name and value *do not* match, it creates an `aliases` entry mapping the
+  service name to the class name, *and* a `factories` entry mapping the class
+  name to `Zend\ServiceManager\Factory\InvokableFactory`.
 
-You will now use the following:
-
-```php
-use Zend\ServiceManager\Factory\InvokableFactory;
-
-return [
-    'factories' => [
-        'MyClass' => InvokableFactory::class,
-    ],
-];
-```
-
-What if you were using a service name that differed from the class name?
-
-```php
-return [
-    'invokables' => [
-        'MyClass' => 'AnotherClass',
-    ],
-];
-```
-
-In this case, you will create two separate entries: an invokable factory for the
-actual class, and an alias to it:
-
-```php
-use Zend\ServiceManager\Factory\InvokableFactory;
-
-return [
-    'aliases' => [
-        'MyClass' => 'AnotherClass',
-    ],
-    'invokables' => [
-        'AnotherClass' => InvokableFactory::class,
-    ],
-];
-```
-
-Alternately, you can create a dedicated factory for `MyClass` that instantiates
-the correct class.
+This means that you can use your existing `invokables` configuration from
+version 2 in version 3. However, we recommend starting to update your
+configuration to remove `invokables` entries in favor of factories (and aliases,
+if needed).
 
 ### Lazy Services
 

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -148,4 +148,35 @@ class ServiceManagerTest extends TestCase
 
         $this->assertEquals($shouldBeSameInstance, $a === $b);
     }
+
+    public function testMapsOneToOneInvokablesAsInvokableFactoriesInternally()
+    {
+        $config = [
+            'invokables' => [
+                InvokableObject::class => InvokableObject::class,
+            ],
+        ];
+
+        $serviceManager = new ServiceManager($config);
+        $this->assertAttributeSame([
+            InvokableObject::class => InvokableFactory::class,
+        ], 'factories', $serviceManager, 'Invokable object factory not found');
+    }
+
+    public function testMapsNonSymmetricInvokablesAsAliasPlusInvokableFactory()
+    {
+        $config = [
+            'invokables' => [
+                'Invokable' => InvokableObject::class,
+            ],
+        ];
+
+        $serviceManager = new ServiceManager($config);
+        $this->assertAttributeSame([
+            'Invokable' => InvokableObject::class,
+        ], 'aliases', $serviceManager, 'Alias not found for non-symmetric invokable');
+        $this->assertAttributeSame([
+            InvokableObject::class => InvokableFactory::class,
+        ], 'factories', $serviceManager, 'Factory not found for non-symmetric invokable target');
+    }
 }


### PR DESCRIPTION
This patch re-instates invokables, but not by re-adding the original functionality, but instead modifing the `configure()` method to create `factories` and `aliases` configuration from the `invokables` configuration, using the following rules:

- If the service name and class name match, it creates a `factories` entry, mapping the service name to an `InvokableFactory`.
- If the service name and class name *do not* match, it creates an `aliases` entry mapping the service name to the class name, and a `factories` entry, mapping the class name to an `InvokableFactory`.

This is exactly what was previously recommended in the migration guide; the patch simply automates it from the configuration.

Using this would remove the largest BC break for end-users.