### PR TITLE
Re-instate config features

### DIFF
--- a/doc/book/migration.md
+++ b/doc/book/migration.md
@@ -159,6 +159,14 @@ class HelperConfig implements ConfigInterface
 }
 ```
 
+### Config class
+
+`Zend\ServiceManager\Config` has been updated to follow the changes to the
+`ConfigInterface` and `ServiceManager`. This essentially means that it removes
+the various getter methods, and that the `configureServiceManager()` method
+instead aggregates the relevant configuration from the configuration passed to
+the constructor to pass to `ServiceManager::withConfig()`.
+
 ## Invokables
 
 *Invokables no longer exist,* at least, not identically to how they existed in
@@ -761,7 +769,6 @@ We may re-introduce it via a separate component in the future.
 
 The following interfaces, traits, and classes were *removed*:
 
-- `Zend\ServiceManager\Config`
 - `Zend\ServiceManager\MutableCreationOptionsInterface`; this was previously
   used by the `AbstractPluginManager`, and is no longer required as we ship a
   separate `PluginManagerInterface`, and because the functionality is
@@ -787,3 +794,6 @@ The following classes and interfaces have changes:
   `ServiceManager` instance. This is because instances cannot be configured
   in-situ; implementers will now need to call `withConfig()` and return the
   instance returned by that method.
+- `Zend\ServiceManager\Config` was updated to follow the changes to
+  `ConfigInterface` and `ServiceManager`, and now returns a new
+  `ServiceManager` instance from `configureServiceManager()`.

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager;
+
+class Config implements ConfigInterface
+{
+    /**
+     * @var array
+     */
+    protected $config = [];
+
+    /**
+     * Constructor
+     *
+     * @param array $config
+     */
+    public function __construct($config = [])
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Configure service manager
+     *
+     * @param ServiceManager $serviceManager
+     * @return ServiceManager Returns a new instance with the merged configuration.
+     */
+    public function configureServiceManager(ServiceManager $serviceManager)
+    {
+        $config            = [];
+        $abstractFactories = isset($this->config['abstract_factories']) ? $this->config['abstract_factories'] : [];
+        $aliases           = isset($this->config['aliases']) ? $this->config['aliases'] : [];
+        $delegators        = isset($this->config['delegators']) ? $this->config['delegators'] : [];
+        $factories         = isset($this->config['factories']) ? $this->config['factories'] : [];
+        $initializers      = isset($this->config['initializers']) ? $this->config['initializers'] : [];
+        $invokables        = isset($this->config['invokables']) ? $this->config['invokables'] : [];
+        $lazyServices      = isset($this->config['lazy_services']) ? $this->config['lazy_services'] : [];
+        $services          = isset($this->config['services']) ? $this->config['services'] : [];
+        $shared            = isset($this->config['shared']) ? $this->config['shared'] : [];
+
+        if (! empty($abstractFactories)) {
+            $config['abstract_factories'] = $abstractFactories;
+        }
+
+        if (! empty($aliases)) {
+            $config['aliases'] = $aliases;
+        }
+
+        if (! empty($delegators)) {
+            $config['delegators'] = $delegators;
+        }
+
+        if (! empty($factories)) {
+            $config['factories'] = $factories;
+        }
+
+        if (! empty($initializers)) {
+            $config['initializers'] = $initializers;
+        }
+
+        if (! empty($invokables)) {
+            $config['invokables'] = $invokables;
+        }
+
+        if (! empty($lazyServices)) {
+            $config['lazy_services'] = $lazyServices;
+        }
+
+        if (! empty($services)) {
+            $config['services'] = $services;
+        }
+
+        if (! empty($shared)) {
+            $config['shared'] = $shared;
+        }
+
+        return $serviceManager->withConfig($config);
+    }
+}

--- a/src/Config.php
+++ b/src/Config.php
@@ -9,21 +9,57 @@
 
 namespace Zend\ServiceManager;
 
+use Zend\Stdlib\ArrayUtils;
+
 class Config implements ConfigInterface
 {
     /**
+     * Allowed configuration keys
+     *
      * @var array
      */
-    protected $config = [];
+    protected $allowedKeys = [
+        'abstract_factories' => true,
+        'aliases'            => true,
+        'delegators'         => true,
+        'factories'          => true,
+        'initializers'       => true,
+        'invokables'         => true,
+        'lazy_services'      => true,
+        'services'           => true,
+        'shared'             => true,
+    ];
+
+    /**
+     * @var array
+     */
+    protected $config = [
+        'abstract_factories' => [],
+        'aliases'            => [],
+        'delegators'         => [],
+        'factories'          => [],
+        'initializers'       => [],
+        'invokables'         => [],
+        'lazy_services'      => [],
+        'services'           => [],
+        'shared'             => [],
+    ];
 
     /**
      * Constructor
      *
      * @param array $config
      */
-    public function __construct($config = [])
+    public function __construct(array $config = [])
     {
-        $this->config = $config;
+        // Only merge keys we're interested in
+        foreach (array_keys($config) as $key) {
+            if (! isset($this->allowedKeys[$key])) {
+                unset($config[$key]);
+            }
+        }
+
+        $this->config = ArrayUtils::merge($this->config, $config);
     }
 
     /**
@@ -34,53 +70,6 @@ class Config implements ConfigInterface
      */
     public function configureServiceManager(ServiceManager $serviceManager)
     {
-        $config            = [];
-        $abstractFactories = isset($this->config['abstract_factories']) ? $this->config['abstract_factories'] : [];
-        $aliases           = isset($this->config['aliases']) ? $this->config['aliases'] : [];
-        $delegators        = isset($this->config['delegators']) ? $this->config['delegators'] : [];
-        $factories         = isset($this->config['factories']) ? $this->config['factories'] : [];
-        $initializers      = isset($this->config['initializers']) ? $this->config['initializers'] : [];
-        $invokables        = isset($this->config['invokables']) ? $this->config['invokables'] : [];
-        $lazyServices      = isset($this->config['lazy_services']) ? $this->config['lazy_services'] : [];
-        $services          = isset($this->config['services']) ? $this->config['services'] : [];
-        $shared            = isset($this->config['shared']) ? $this->config['shared'] : [];
-
-        if (! empty($abstractFactories)) {
-            $config['abstract_factories'] = $abstractFactories;
-        }
-
-        if (! empty($aliases)) {
-            $config['aliases'] = $aliases;
-        }
-
-        if (! empty($delegators)) {
-            $config['delegators'] = $delegators;
-        }
-
-        if (! empty($factories)) {
-            $config['factories'] = $factories;
-        }
-
-        if (! empty($initializers)) {
-            $config['initializers'] = $initializers;
-        }
-
-        if (! empty($invokables)) {
-            $config['invokables'] = $invokables;
-        }
-
-        if (! empty($lazyServices)) {
-            $config['lazy_services'] = $lazyServices;
-        }
-
-        if (! empty($services)) {
-            $config['services'] = $services;
-        }
-
-        if (! empty($shared)) {
-            $config['shared'] = $shared;
-        }
-
-        return $serviceManager->withConfig($config);
+        return $serviceManager->withConfig($this->config);
     }
 }

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager;
+
+interface ConfigInterface
+{
+    /**
+     * Configure a service manager.
+     *
+     * Implementations should pull configuration from somewhere (typically
+     * local properties) and pass it to a ServiceManager's withConfig() method,
+     * returning a new instance.
+     *
+     * @param ServiceManager $serviceManager
+     * @return ServiceManager
+     */
+    public function configureServiceManager(ServiceManager $serviceManager);
+}

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ServiceManager\Config;
+use Zend\ServiceManager\ServiceManager;
+
+class ConfigTest extends TestCase
+{
+    public function testPassesKnownServiceConfigKeysToServiceManagerWithConfigMethod()
+    {
+        $expected = [
+            'abstract_factories' => [
+                __CLASS__,
+                __NAMESPACE__,
+            ],
+            'aliases' => [
+                'foo' => __CLASS__,
+                'bar' => __NAMESPACE__,
+            ],
+            'delegators' => [
+                'foo' => [
+                    __CLASS__,
+                    __NAMESPACE__,
+                ]
+            ],
+            'factories' => [
+                'foo' => __CLASS__,
+                'bar' => __NAMESPACE__,
+            ],
+            'initializers' => [
+                __CLASS__,
+                __NAMESPACE__,
+            ],
+            'invokables' => [
+                'foo' => __CLASS__,
+                'bar' => __NAMESPACE__,
+            ],
+            'lazy_services' => [
+                'class_map' => [
+                    __CLASS__     => __CLASS__,
+                    __NAMESPACE__ => __NAMESPACE__,
+                ],
+            ],
+            'services' => [
+                'foo' => $this,
+            ],
+            'shared' => [
+                __CLASS__     => true,
+                __NAMESPACE__ => false,
+            ],
+        ];
+
+        $config = $expected + [
+            'foo' => 'bar',
+            'baz' => 'bat',
+        ];
+
+        $services = $this->prophesize(ServiceManager::class);
+        $services->withConfig($expected)->willReturn('CALLED');
+
+        $configuration = new Config($config);
+        $this->assertEquals('CALLED', $configuration->configureServiceManager($services->reveal()));
+    }
+}


### PR DESCRIPTION
This patch re-instates the `ConfigInterface` and `Config` class, with updates to follow the other changes in the component:

- `ConfigInterface::configureServiceManager()` is now specified as returning a *new* `ServiceManager` instance.
- `Config` now aggregates configuration and passes it to `ServiceManager::withConfig()`, returning the resulting cloned instance.

This was done due to the copius usage of both within components, to facilitate migration.