### PR TITLE
Add method for retrieving configuration to ConfigInterface

### DIFF
--- a/doc/book/migration.md
+++ b/doc/book/migration.md
@@ -159,6 +159,10 @@ class HelperConfig implements ConfigInterface
 }
 ```
 
+Additionally, we have **added** another method to `ConfigInterface`,
+`toArray()`. This should return an array in a format that can be passed to the
+`ServiceManager`'s constructor or `withConfig()` method.
+
 ### Config class
 
 `Zend\ServiceManager\Config` has been updated to follow the changes to the

--- a/src/Config.php
+++ b/src/Config.php
@@ -72,4 +72,12 @@ class Config implements ConfigInterface
     {
         return $serviceManager->withConfig($this->config);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function toArray()
+    {
+        return $this->config;
+    }
 }

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -22,4 +22,27 @@ interface ConfigInterface
      * @return ServiceManager
      */
     public function configureServiceManager(ServiceManager $serviceManager);
+
+    /**
+     * Return configuration for a service manager instance as an array.
+     *
+     * Implementations MUST return an array compatible with ServiceManager::configure,
+     * containing one or more of the following keys:
+     *
+     * - abstract_factories
+     * - aliases
+     * - delegators
+     * - factories
+     * - initializers
+     * - invokables
+     * - lazy_services
+     * - services
+     * - shared
+     *
+     * In other words, this should return configuration that can be used to instantiate
+     * a service manager or plugin manager, or pass to its `withConfig()` method.
+     *
+     * @return array
+     */
+    public function toArray();
 }

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -69,5 +69,20 @@ class ConfigTest extends TestCase
 
         $configuration = new Config($config);
         $this->assertEquals('CALLED', $configuration->configureServiceManager($services->reveal()));
+
+        return [
+            'array'  => $expected,
+            'config' => $configuration,
+        ];
+    }
+
+    /**
+     * @depends testPassesKnownServiceConfigKeysToServiceManagerWithConfigMethod
+     */
+    public function testToArrayReturnsConfiguration($dependencies)
+    {
+        $configuration  = $dependencies['array'];
+        $configInstance = $dependencies['config'];
+        $this->assertSame($configuration, $configInstance->toArray());
     }
 }


### PR DESCRIPTION
Added `toArray()` method to `ConfigInterface` to provide a mechanism for fetching configuration without needing to configure the service manager. This will be useful in particular for `Zend\ModuleManager\Listener\ServiceListener`, which primarily needs to aggregate and merge configuration *prior* to creating a new instance of a plugin manager.

An implementation was added to the `Config` class, along with tests.