### PR TITLE
Cache by requested service name

### DIFF
--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -179,4 +179,46 @@ class ServiceManagerTest extends TestCase
             InvokableObject::class => InvokableFactory::class,
         ], 'factories', $serviceManager, 'Factory not found for non-symmetric invokable target');
     }
+
+    /**
+     * @depends testMapsNonSymmetricInvokablesAsAliasPlusInvokableFactory
+     */
+    public function testSharedServicesReferencingInvokableAliasShouldBeHonored()
+    {
+        $config = [
+            'invokables' => [
+                'Invokable' => InvokableObject::class,
+            ],
+            'shared' => [
+                'Invokable' => false,
+            ],
+        ];
+
+        $serviceManager = new ServiceManager($config);
+        $instance1 = $serviceManager->get('Invokable');
+        $instance2 = $serviceManager->get('Invokable');
+
+        $this->assertNotSame($instance1, $instance2);
+    }
+
+    public function testSharedServicesReferencingAliasShouldBeHonored()
+    {
+        $config = [
+            'aliases' => [
+                'Invokable' => InvokableObject::class,
+            ],
+            'factories' => [
+                InvokableObject::class => InvokableFactory::class,
+            ],
+            'shared' => [
+                'Invokable' => false,
+            ],
+        ];
+
+        $serviceManager = new ServiceManager($config);
+        $instance1 = $serviceManager->get('Invokable');
+        $instance2 = $serviceManager->get('Invokable');
+
+        $this->assertNotSame($instance1, $instance2);
+    }
 }


### PR DESCRIPTION
Previous behavior of the service manager allowed specifying aliases when creating the `shared` configuration. Prior to this patch, that did not work with the refactored code.

This patch updates the code to check for a cached service under the _requested_ service name, not the _resolved_ service name, which allows specifying sharing configuration based on aliases.

Internally, it caches up to twice:

- If the resolved service name is supposed to be shared, it will cache under the resolved name.
- If the requested service name is supposed to be shared, it will cache under the resolved name.

This allows having separate instances based on service name.

(Issue created due to observed issue when refactoring zend-view to use the dev-develop branch of zend-servicemanager.)