### PR TITLE
Added the first benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ retrieving other objects.
 
 - File issues at https://github.com/zendframework/zend-servicemanager/issues
 - Documentation is at http://framework.zend.com/manual/current/en/index.html#zend-servicemanager
+
+## Benchmarks
+
+We provide scripts for benchmarking zend-eventmanager using the
+[Athletic](https://github.com/polyfractal/athletic) framework; these can be
+found in the `benchmarks/` directory.
+
+To execute the benchmarks you can run the following command:
+
+```bash
+$ vendor/bin/athletic -p benchmarks
+```

--- a/benchmarks/FetchServices.php
+++ b/benchmarks/FetchServices.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace ZendBench\ServiceManager;
+
+use Zend\ServiceManager\ServiceManager;
+use Athletic\AthleticEvent;
+
+class FetchServices extends AthleticEvent
+{
+    const NUM_SERVICES = 50;
+
+    /**
+     * @var ServiceManager
+     */
+    protected $sm;
+
+    public function setUp()
+    {
+        $this->sm = new ServiceManager();
+        // factories
+        for ($i = 0; $i < self::NUM_SERVICES; $i++) {
+            $this->sm->setFactory("factory_$i", 'ZendTest\ServiceManager\TestAsset\FooFactory');
+            $this->sm->setInvokableClass("invokable_$i", 'ZendTest\ServiceManager\TestAsset\Foo');
+            $this->sm->setService("service_$i", new \ZendTest\ServiceManager\TestAsset\Foo);
+            $this->sm->setAlias("alias_$i", "service_$i");
+        }
+        // abstract factory
+        $this->sm->addAbstractFactory('ZendTest\ServiceManager\TestAsset\FooAbstractFactory');
+        $this->sm->addAbstractFactory('ZendTest\ServiceManager\TestAsset\BarAbstractFactory');
+    }
+
+    /**
+     * Fetch the factory services
+     *
+     * @iterations 1000
+     */
+    public function fetchFactoryService()
+    {
+        $result = $this->sm->get(sprintf("factory_%d", rand(0, self::NUM_SERVICES - 1)));
+    }
+
+    /**
+     * Fetch the invokable services
+     *
+     * @iterations 1000
+     */
+    public function fetchInvokableService()
+    {
+        $result = $this->sm->get(sprintf("invokable_%d", rand(0, self::NUM_SERVICES - 1)));
+    }
+
+    /**
+     * Fetch the services
+     *
+     * @iterations 1000
+     */
+    public function fetchService()
+    {
+        $result = $this->sm->get(sprintf("service_%d", rand(0, self::NUM_SERVICES - 1)));
+    }
+
+    /**
+     * Fetch the alias services
+     *
+     * @iterations 1000
+     */
+    public function fetchAliasService()
+    {
+        $result = $this->sm->get(sprintf("alias_%d", rand(0, self::NUM_SERVICES - 1)));
+    }
+
+    /**
+     * Fetch the abstract factory services
+     *
+     * @iterations 1000
+     */
+    public function fetchAbstractFactoryService()
+    {
+       $result = $this->sm->get(rand(0,1) ? 'foo' : 'bar');
+    }
+}

--- a/benchmarks/FetchServices.php
+++ b/benchmarks/FetchServices.php
@@ -18,7 +18,7 @@ class FetchServices extends AthleticEvent
     {
         $this->sm = new ServiceManager();
         // factories
-        for ($i = 0; $i < self::NUM_SERVICES; $i++) {
+        for ($i = 0; $i <= self::NUM_SERVICES; $i++) {
             $this->sm->setFactory("factory_$i", 'ZendTest\ServiceManager\TestAsset\FooFactory');
             $this->sm->setInvokableClass("invokable_$i", 'ZendTest\ServiceManager\TestAsset\Foo');
             $this->sm->setService("service_$i", new \ZendTest\ServiceManager\TestAsset\Foo);
@@ -36,7 +36,7 @@ class FetchServices extends AthleticEvent
      */
     public function fetchFactoryService()
     {
-        $result = $this->sm->get(sprintf("factory_%d", rand(0, self::NUM_SERVICES - 1)));
+        $result = $this->sm->get('factory_' . rand(0, self::NUM_SERVICES));
     }
 
     /**
@@ -46,7 +46,7 @@ class FetchServices extends AthleticEvent
      */
     public function fetchInvokableService()
     {
-        $result = $this->sm->get(sprintf("invokable_%d", rand(0, self::NUM_SERVICES - 1)));
+        $result = $this->sm->get('invokable_' . rand(0, self::NUM_SERVICES));
     }
 
     /**
@@ -56,7 +56,7 @@ class FetchServices extends AthleticEvent
      */
     public function fetchService()
     {
-        $result = $this->sm->get(sprintf("service_%d", rand(0, self::NUM_SERVICES - 1)));
+        $result = $this->sm->get('service_' . rand(0, self::NUM_SERVICES));
     }
 
     /**
@@ -66,7 +66,7 @@ class FetchServices extends AthleticEvent
      */
     public function fetchAliasService()
     {
-        $result = $this->sm->get(sprintf("alias_%d", rand(0, self::NUM_SERVICES - 1)));
+        $result = $this->sm->get('alias_' . rand(0, self::NUM_SERVICES));
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
     },
     "require": {
         "php": ">=5.5",
-        "container-interop/container-interop": "~1.0",
-        "athletic/athletic": "dev-master"
+        "container-interop/container-interop": "~1.0"
     },
     "require-dev": {
         "zendframework/zend-di": "~2.5",
         "zendframework/zend-mvc": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "~4.0"
+        "phpunit/PHPUnit": "~4.0",
+        "athletic/athletic": "dev-master"
     },
     "suggest": {
         "ocramius/proxy-manager": "ProxyManager 0.5.* to handle lazy initialization of services",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     },
     "require": {
         "php": ">=5.5",
-        "container-interop/container-interop": "~1.0"
+        "container-interop/container-interop": "~1.0",
+        "athletic/athletic": "dev-master"
     },
     "require-dev": {
         "zendframework/zend-di": "~2.5",
@@ -36,7 +37,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "ZendTest\\ServiceManager\\": "test/"
+            "ZendTest\\ServiceManager\\": "test/",
+            "ZendBench\\ServiceManager\\": "benchmarks/"
         }
     }
 }


### PR DESCRIPTION
This PR adds the first benchmarks for ServiceManager. I created a first round of benchmarking fetching the following services:
- factories;
- invokables;
- alias;
- services;
- abstract services;

These the results of the execution on a CPU Intel i5-2500 at 3.30GHz, 8 GB RAM, Ubuntu 14.04, PHP 5.5.9:
```
ZendBench\ServiceManager\FetchServices
    Method Name                   Iterations   Average Time      Ops/second   
    ---------------------------- ------------ ----------------- ---------------
    fetchFactoryService        : [     1,000] [0.0000220508575] [45,349.71023 ]
    fetchInvokableService      : [     1,000] [0.0000179929733] [55,577.25129 ]
    fetchService               : [     1,000] [0.0000026111603] [382,971.51205]
    fetchAliasService          : [     1,000] [0.0000124194622] [80,518.78443 ]
    fetchAbstractFactoryService: [     1,000] [0.0000263185501] [37,996.01406 ]
```