### PR TITLE
Ensure plugin manager creation context travels with clone

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -147,7 +147,7 @@ class ServiceManager implements ServiceLocatorInterface
     public function withConfig(array $config)
     {
         $container                  = clone $this;
-        $container->creationContext = $container;
+        $container->creationContext = ($this === $this->creationContext) ? $container : $this->creationContext;
         $container->configure($config);
         return $container;
     }


### PR DESCRIPTION
Prior to this patch, calling `withConfig()` on a plugin manager would reset the `creationContext` to the plugin manager itself — instead of retaining the original creation context. This patch overrides the `withConfig()` method to set the creation context to the original within the cloned instance.