### PR TITLE
Ensure aliases can reference explicit services

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -166,6 +166,16 @@ class ServiceManager implements ServiceLocatorInterface
             return $this->services[$requestedName];
         }
 
+        // Next, if the alias should be shared, and we have cached the resolved
+        // service, use it.
+        if ($requestedName !== $name
+            && (! isset($this->shared[$requestedName]) || $this->shared[$requestedName])
+            && isset($this->services[$name])
+        ) {
+            $this->services[$requestedName] = $this->services[$name];
+            return $this->services[$name];
+        }
+
         // At this point, we need to create the instance; we use the resolved
         // name for that.
         $object = $this->doCreate($name);

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -221,4 +221,23 @@ class ServiceManagerTest extends TestCase
 
         $this->assertNotSame($instance1, $instance2);
     }
+
+    public function testAliasToAnExplicitServiceShouldWork()
+    {
+        $config = [
+            'aliases' => [
+                'Invokable' => InvokableObject::class,
+            ],
+            'services' => [
+                InvokableObject::class => new InvokableObject(),
+            ],
+        ];
+
+        $serviceManager = new ServiceManager($config);
+
+        $service = $serviceManager->get(InvokableObject::class);
+        $alias   = $serviceManager->get('Invokable');
+
+        $this->assertSame($service, $alias);
+    }
 }


### PR DESCRIPTION
With the most recent changes to allow unshared aliases, aliases to explicitly registered services no longer worked. This patch adds logic to get() to check if:

- the alias is shared, AND
- the resolved service is present

and, if so, registers the service under the alias, returning it.