### PR TITLE
Add the benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ retrieving other objects.
 
 ## Benchmarks
 
-We provide scripts for benchmarking zend-eventmanager using the
+We provide scripts for benchmarking zend-servicemanager using the
 [Athletic](https://github.com/polyfractal/athletic) framework; these can be
 found in the `benchmarks/` directory.
 

--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ retrieving other objects.
 
 - File issues at https://github.com/zendframework/zend-servicemanager/issues
 - Documentation is at http://framework.zend.com/manual/current/en/index.html#zend-servicemanager
+
+## Benchmarks
+
+We provide scripts for benchmarking zend-eventmanager using the
+[Athletic](https://github.com/polyfractal/athletic) framework; these can be
+found in the `benchmarks/` directory.
+
+To execute the benchmarks you can run the following command:
+
+```bash
+$ vendor/bin/athletic -p benchmarks
+```

--- a/benchmarks/BenchAsset/AbstractFactoryFoo.php
+++ b/benchmarks/BenchAsset/AbstractFactoryFoo.php
@@ -1,0 +1,21 @@
+<?php
+namespace ZendBench\ServiceManager\BenchAsset;
+
+use Zend\ServiceManager\Factory\AbstractFactoryInterface;
+use Interop\Container\ContainerInterface;
+
+class AbstractFactoryFoo implements AbstractFactoryInterface
+{
+    public function canCreateServiceWithName(ContainerInterface $container, $requestedName)
+    {
+        return ($requestedName === 'foo');
+    }
+
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        if ($requestedName === 'foo') {
+            return new Foo($options);
+        }
+        return false;
+    }
+}

--- a/benchmarks/BenchAsset/FactoryFoo.php
+++ b/benchmarks/BenchAsset/FactoryFoo.php
@@ -1,0 +1,13 @@
+<?php
+namespace ZendBench\ServiceManager\BenchAsset;
+
+use Zend\ServiceManager\Factory\FactoryInterface;
+use Interop\Container\ContainerInterface;
+
+class FactoryFoo implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        return new Foo($options);
+    }
+}

--- a/benchmarks/BenchAsset/Foo.php
+++ b/benchmarks/BenchAsset/Foo.php
@@ -1,0 +1,12 @@
+<?php
+namespace ZendBench\ServiceManager\BenchAsset;
+
+class Foo
+{
+    protected $options;
+
+    public function __construct($options = null)
+    {
+        $this->options = $options;
+    }
+}

--- a/benchmarks/FetchServices.php
+++ b/benchmarks/FetchServices.php
@@ -7,7 +7,7 @@ use Zend\ServiceManager\ServiceManager;
 
 class FetchServices extends AthleticEvent
 {
-    const NUM_SERVICES = 50;
+    const NUM_SERVICES = 1000;
 
     /**
      * @var ServiceManager
@@ -35,7 +35,7 @@ class FetchServices extends AthleticEvent
     /**
      * Fetch the factory services
      *
-     * @iterations 1000
+     * @iterations 5000
      */
     public function fetchFactoryService()
     {
@@ -45,7 +45,7 @@ class FetchServices extends AthleticEvent
     /**
      * Fetch the invokable services
      *
-     * @iterations 1000
+     * @iterations 5000
      */
     public function fetchInvokableService()
     {
@@ -55,7 +55,7 @@ class FetchServices extends AthleticEvent
     /**
      * Fetch the services
      *
-     * @iterations 1000
+     * @iterations 5000
      */
     public function fetchService()
     {
@@ -65,7 +65,7 @@ class FetchServices extends AthleticEvent
     /**
      * Fetch the alias services
      *
-     * @iterations 1000
+     * @iterations 5000
      */
     public function fetchAliasService()
     {
@@ -75,7 +75,7 @@ class FetchServices extends AthleticEvent
     /**
      * Fetch the abstract factory services
      *
-     * @iterations 1000
+     * @iterations 5000
      */
     public function fetchAbstractFactoryService()
     {

--- a/benchmarks/FetchServices.php
+++ b/benchmarks/FetchServices.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace ZendBench\ServiceManager;
+
+use Athletic\AthleticEvent;
+use Zend\ServiceManager\ServiceManager;
+
+class FetchServices extends AthleticEvent
+{
+    const NUM_SERVICES = 50;
+
+    /**
+     * @var ServiceManager
+     */
+    protected $sm;
+
+    protected function getConfig()
+    {
+        $config = [];
+        for ($i = 0; $i <= self::NUM_SERVICES; $i++) {
+            $config['factories']["factory_$i"]    = BenchAsset\FactoryFoo::class;
+            $config['invokables']["invokable_$i"] = BenchAsset\Foo::class;
+            $config['services']["service_$i"]     = $this;
+            $config['aliases']["alias_$i"]        = "service_$i";
+        }
+        $config['abstract_factories'] = [ BenchAsset\AbstractFactoryFoo::class ];
+        return $config;
+    }
+
+    public function classSetUp()
+    {
+        $this->sm = new ServiceManager($this->getConfig());
+    }
+
+    /**
+     * Fetch the factory services
+     *
+     * @iterations 1000
+     */
+    public function fetchFactoryService()
+    {
+        $result = $this->sm->get('factory_' . rand(0, self::NUM_SERVICES));
+    }
+
+    /**
+     * Fetch the invokable services
+     *
+     * @iterations 1000
+     */
+    public function fetchInvokableService()
+    {
+        $result = $this->sm->get('invokable_' . rand(0, self::NUM_SERVICES));
+    }
+
+    /**
+     * Fetch the services
+     *
+     * @iterations 1000
+     */
+    public function fetchService()
+    {
+        $result = $this->sm->get('service_' . rand(0, self::NUM_SERVICES));
+    }
+
+    /**
+     * Fetch the alias services
+     *
+     * @iterations 1000
+     */
+    public function fetchAliasService()
+    {
+        $result = $this->sm->get('alias_' . rand(0, self::NUM_SERVICES));
+    }
+
+    /**
+     * Fetch the abstract factory services
+     *
+     * @iterations 1000
+     */
+    public function fetchAbstractFactoryService()
+    {
+       $result = $this->sm->get('foo');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require-dev": {
         "phpunit/phpunit": "~4.6",
         "ocramius/proxy-manager": "~1.0",
-        "squizlabs/php_codesniffer": "^2.0@dev"
+        "squizlabs/php_codesniffer": "^2.0@dev",
+        "athletic/athletic": "dev-master"
     },
     "suggest": {
         "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services"
@@ -35,7 +36,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "ZendTest\\ServiceManager\\": "test/"
+            "ZendTest\\ServiceManager\\": "test/",
+            "ZendBench\\ServiceManager\\": "benchmarks/"
         }
     }
 }


### PR DESCRIPTION
This PR adds the benchmarks using [athletic](https://github.com/polyfractal/athletic) framework. The benchmarks are based on the develop branch, containing the ZF3 service manager.
When merged, I'll change it to work in master so we can have a comparison of the performance.