### PR TITLE
Fit the same benchmark tests of develop in master

### DIFF
--- a/benchmarks/BenchAsset/AbstractFactoryFoo.php
+++ b/benchmarks/BenchAsset/AbstractFactoryFoo.php
@@ -1,0 +1,21 @@
+<?php
+namespace ZendBench\ServiceManager\BenchAsset;
+
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class AbstractFactoryFoo implements AbstractFactoryInterface
+{
+  public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+  {
+      if ($name != 'foo') {
+          return false;
+      }
+      return true;
+  }
+
+  public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+  {
+      return new Foo();
+  }
+}

--- a/benchmarks/BenchAsset/FactoryFoo.php
+++ b/benchmarks/BenchAsset/FactoryFoo.php
@@ -1,0 +1,13 @@
+<?php
+namespace ZendBench\ServiceManager\BenchAsset;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FactoryFoo implements FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return new Foo();
+    }
+}

--- a/benchmarks/BenchAsset/Foo.php
+++ b/benchmarks/BenchAsset/Foo.php
@@ -1,0 +1,12 @@
+<?php
+namespace ZendBench\ServiceManager\BenchAsset;
+
+class Foo
+{
+    protected $options;
+
+    public function __construct($options = null)
+    {
+        $this->options = $options;
+    }
+}

--- a/benchmarks/FetchServices.php
+++ b/benchmarks/FetchServices.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace ZendBench\ServiceManager;
+
+use Athletic\AthleticEvent;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Config;
+
+class FetchServices extends AthleticEvent
+{
+    const NUM_SERVICES = 1000;
+
+    /**
+     * @var ServiceManager
+     */
+    protected $sm;
+
+    protected function getConfig()
+    {
+        $config = [];
+        for ($i = 0; $i <= self::NUM_SERVICES; $i++) {
+            $config['factories']["factory_$i"]    = BenchAsset\FactoryFoo::class;
+            $config['invokables']["invokable_$i"] = BenchAsset\Foo::class;
+            $config['services']["service_$i"]     = $this;
+            $config['aliases']["alias_$i"]        = "service_$i";
+        }
+        $config['abstract_factories'] = [ BenchAsset\AbstractFactoryFoo::class ];
+        return $config;
+    }
+
+    public function classSetUp()
+    {
+        $this->sm = new ServiceManager(new Config($this->getConfig()));
+    }
+
+    /**
+     * Fetch the factory services
+     *
+     * @iterations 5000
+     */
+    public function fetchFactoryService()
+    {
+        $result = $this->sm->get('factory_' . rand(0, self::NUM_SERVICES));
+    }
+
+    /**
+     * Fetch the invokable services
+     *
+     * @iterations 5000
+     */
+    public function fetchInvokableService()
+    {
+        $result = $this->sm->get('invokable_' . rand(0, self::NUM_SERVICES));
+    }
+
+    /**
+     * Fetch the services
+     *
+     * @iterations 5000
+     */
+    public function fetchService()
+    {
+        $result = $this->sm->get('service_' . rand(0, self::NUM_SERVICES));
+    }
+
+    /**
+     * Fetch the alias services
+     *
+     * @iterations 5000
+     */
+    public function fetchAliasService()
+    {
+        $result = $this->sm->get('alias_' . rand(0, self::NUM_SERVICES));
+    }
+
+    /**
+     * Fetch the abstract factory services
+     *
+     * @iterations 5000
+     */
+    public function fetchAbstractFactoryService()
+    {
+       $result = $this->sm->get('foo');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "zendframework/zend-di": "~2.5",
         "zendframework/zend-mvc": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "~4.0"
+        "phpunit/PHPUnit": "~4.0",
+        "athletic/athletic": "dev-master"
     },
     "suggest": {
         "ocramius/proxy-manager": "ProxyManager 0.5.* to handle lazy initialization of services",
@@ -36,7 +37,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "ZendTest\\ServiceManager\\": "test/"
+            "ZendTest\\ServiceManager\\": "test/",
+            "ZendBench\\ServiceManager\\": "benchmarks/"
         }
     }
 }


### PR DESCRIPTION
This PR fits the same benchmark test of develop in master. This can show the performance improvement of zend-servicemanager from ZF2 to ZF3.

The following tests show that the new zend-servicemanager of **ZF3 is from 2x to 4x times faster than ZF2**. 

Execution on master branch (ZF2)
---
```
ZendBench\ServiceManager\FetchServices
    Method Name                   Iterations   Average Time      Ops/second   
    ---------------------------- ------------ ----------------- ---------------
    fetchFactoryService        : [     5,000] [0.0000056037426] [178,452.16518]
    fetchInvokableService      : [     5,000] [0.0000046833515] [213,522.30266]
    fetchService               : [     5,000] [0.0000016517639] [605,413.39492]
    fetchAliasService          : [     5,000] [0.0000050172806] [199,311.15757]
    fetchAbstractFactoryService: [     5,000] [0.0000010243893] [976,191.40716]
```

Execution on develop branch (ZF3)
---
```
ZendBench\ServiceManager\FetchServices
    Method Name                   Iterations   Average Time      Ops/second     
    ---------------------------- ------------ ----------------- -----------------
    fetchFactoryService        : [     5,000] [0.0000016966343] [589,402.20904  ]
    fetchInvokableService      : [     5,000] [0.0000010655403] [938,491.00510  ]
    fetchService               : [     5,000] [0.0000007947922] [1,258,190.54476]
    fetchAliasService          : [     5,000] [0.0000011542320] [866,376.93134  ]
    fetchAbstractFactoryService: [     5,000] [0.0000003638268] [2,748,560.94364]
```

Tested executed on a CPU Intel i5-2500 at 3.30GHz, 8 GB ram, PHP 5.5.9, Ubuntu 14.04.