### PR TITLE
Error in Quick-Start with build() method

### DIFF
--- a/doc/book/quick-start.md
+++ b/doc/book/quick-start.md
@@ -63,5 +63,5 @@ You can use the `build()` method to retrieve discrete instances for a service:
 $object1 = $serviceManager->build(stdClass::class);
 $object2 = $serviceManager->build(stdClass::class);
 
-var_dump($object1 === $object2); // prints "true"
+var_dump($object1 === $object2); // prints "false"
 ```


### PR DESCRIPTION
If we request an instance with the `build()` method shouldn't we get a new instance for every call? If so, the comparison should print `false` instead of `true`, shouldn't it?