### PR TITLE
Removed $checkAbstractFactories flag from has()

### DIFF
--- a/doc/book/migration.md
+++ b/doc/book/migration.md
@@ -428,42 +428,6 @@ $alsoBetween = $container->build(Between::class, [
 The above two validators would be different instances, with their own
 configuration.
 
-### has() no longer checks abstract factories by default
-
-In v2, `has()` would also check abstract factories to see if any would match the
-service. Depending on the number of abstract factories present, this can be an
-expensive operation. As a result, in v3, we no longer check abstract factories
-*by default*.
-
-However, you *can* tell the Service Manager to check them by passing an optional
-second argument to the method; a boolean is expected, and a `true` value
-indicates that abstract factories should be checked:
-
-```php
-$container = new ServiceManager([
-    'factories' => [
-        'MyClass' => 'MyClass',
-    ],
-    'abstract_factories' => [
-        'AbstractFactoryThatAlwaysResolves',
-    ],
-]);
-```
-
-Assuming that `AbstractFactoryThatAlwaysResolves` will resolve any service
-(don't ever do this!), the following behavior is expected:
-
-```php
-$has = $container->has('MyClass');            // always true; factory is defined
-                                              // for the service.
-$has = $container->has('AnotherClass');       // false; no factory is defined
-                                              // for the service, and not
-                                              // looking in abstract factories.
-$has = $container->has('AnotherClass', true); // true; no factory is defined for
-                                              // the service, but we indicated
-                                              // we'd look in abstract factories.
-```
-
 ## Factories
 
 All factory interfaces were moved to a `Factory` subnamespace. Additionally, the

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -211,12 +211,12 @@ class ServiceManager implements ServiceLocatorInterface
     /**
      * {@inheritDoc}
      */
-    public function has($name, $checkAbstractFactories = false)
+    public function has($name)
     {
         $name  = isset($this->resolvedAliases[$name]) ? $this->resolvedAliases[$name] : $name;
         $found = isset($this->services[$name]) || isset($this->factories[$name]);
 
-        if ($found || !$checkAbstractFactories) {
+        if ($found) {
             return $found;
         }
 

--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -156,19 +156,7 @@ trait CommonServiceLocatorBehaviorsTrait
         $this->assertFalse($serviceManager->has('baz'));
     }
 
-    public function testCanCheckServiceExistenceWithoutCheckingAbstractFactories()
-    {
-        $serviceManager = $this->createContainer([
-            'factories' => [
-                stdClass::class => InvokableFactory::class
-            ]
-        ]);
-
-        $this->assertTrue($serviceManager->has(stdClass::class));
-        $this->assertFalse($serviceManager->has(DateTime::class));
-    }
-
-    public function testCanCheckServiceExistenceWithCheckingAbstractFactories()
+    public function testCheckingServiceExistenceWithChecksAgainstAbstractFactories()
     {
         $serviceManager = $this->createContainer([
             'factories' => [
@@ -179,8 +167,8 @@ trait CommonServiceLocatorBehaviorsTrait
             ]
         ]);
 
-        $this->assertTrue($serviceManager->has(stdClass::class, true));
-        $this->assertTrue($serviceManager->has(DateTime::class, true));
+        $this->assertTrue($serviceManager->has(stdClass::class));
+        $this->assertTrue($serviceManager->has(DateTime::class));
     }
 
     public function testBuildNeverSharesInstances()
@@ -322,23 +310,6 @@ trait CommonServiceLocatorBehaviorsTrait
         $this->assertTrue($serviceManager->has(stdClass::class));
     }
 
-    /**
-     * @group has
-     */
-    public function testHasDoesNotCheckAbstractFactoriesByDefault()
-    {
-        $serviceManager = $this->createContainer([
-            'factories' => [
-                stdClass::class => InvokableFactory::class,
-            ],
-            'abstract_factories' => [
-                new SimpleAbstractFactory(),
-            ],
-        ]);
-
-        $this->assertFalse($serviceManager->has(DateTime::class));
-    }
-
     public function abstractFactories()
     {
         return [
@@ -351,7 +322,7 @@ trait CommonServiceLocatorBehaviorsTrait
      * @group has
      * @dataProvider abstractFactories
      */
-    public function testHasCanCheckAbstractFactoriesWhenRequested($abstractFactory, $expected)
+    public function testHasChecksAgainstAbstractFactories($abstractFactory, $expected)
     {
         $serviceManager = $this->createContainer([
             'abstract_factories' => [
@@ -359,7 +330,7 @@ trait CommonServiceLocatorBehaviorsTrait
             ],
         ]);
 
-        $this->assertSame($expected, $serviceManager->has(DateTime::class, true));
+        $this->assertSame($expected, $serviceManager->has(DateTime::class));
     }
 
     /**


### PR DESCRIPTION
In updating zend-mvc to v3 of zend-servicemanager, I ran into a subtle issue: `has()` does not look in abstract factories by default, and requires that you pass an additional flag, `$checkAbstractFactories`, with a boolean true value, if you want to test if an abstract factory can resolve the given `$name`.

This breaks the Liskov Substitution Principal, as it means that the behavior of `has()` depends on how the ServiceManager is configured. Users then must be aware that an abstract factory might supply a dependency, and cannot rely on `has()` per the container-interop contract to work for the specific use case of zend-servicemanager.

As such, this patch removes the flag, and checks abstract factories whenever a service or factory matching the provided `$name` is not found.