### PR TITLE
 Added missing withConfig(array $config) method in ServiceManager class 

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -141,6 +141,19 @@ class ServiceManager implements ServiceLocatorInterface
     }
 
     /**
+     * Configure ServiceManager
+     *
+     * See {@see \Zend\ServiceManager\ServiceManager::configure()} for details
+     * on what $config accepts.
+     * @param array $config
+     */
+    public function withConfig(array $config = [])
+    {
+        $this->configure($config);
+        return $this;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function get($name)

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -146,6 +146,7 @@ class ServiceManager implements ServiceLocatorInterface
      * See {@see \Zend\ServiceManager\ServiceManager::configure()} for details
      * on what $config accepts.
      * @param array $config
+     * @return self
      */
     public function withConfig(array $config = [])
     {

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -252,7 +252,7 @@ class ServiceManagerTest extends TestCase
                 DateTime::class => InvokableFactory::class
             ]
         ]);
-        
+
         $this->assertTrue($serviceManager->has(DateTime::class));
     }
 }

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -243,4 +243,16 @@ class ServiceManagerTest extends TestCase
 
         $this->assertSame($service, $alias);
     }
+
+    public function testWithConfigShouldConfigureService()
+    {
+        $serviceManager = new SimpleServiceManager();
+        $serviceManager->withConfig([
+            'factories' => [
+                DateTime::class => InvokableFactory::class
+            ]
+        ]);
+        
+        $this->assertTrue($serviceManager->has(DateTime::class));
+    }
 }


### PR DESCRIPTION
It documented in doc migrations:

```php
        return $serviceManager->withConfig([
            'invokables' => $this->invokables,
        ]);
```
but there is no method `withConfig()` in ServiceManager class.

/cc @weierophinney 