### PR TITLE
Forward compatibility features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ All notable changes to this project will be documented in this file, in reverse 
   Of course, you can still override the `validate` method if your logic is more
   complex.
 
+  To aid migration, `validate()` will check for a `validatePlugin()` method (which
+  was required in v2), and proxy to it if found, after emitting an
+  `E_USER_DEPRECATED` notice prompting you to rename the method.
+
 - A new method, `configure()`, was added, allowing full configuration of the
   `ServiceManager` instance at once. Each of the various configuration methods —
   `setAlias()`, `setInvokableClass()`, etc. — now proxy to this method.
@@ -168,8 +172,13 @@ changes, outlined in this section.
   enforced through the interface, that allows you to easily map multiple service
   names to the same factory.
 
+  To provide forwards compatibility, the original interfaces have been retained,
+  but extend the new interfaces (which are under new namespaces). You can implement
+  the new methods in your existing v2 factories in order to make them forwards
+  compatible with v3.
+
 - The for `AbstractFactoryInterface` interface renames the method `canCreateServiceWithName()`
-  to `has()`, and merges the `$name` and `$requestedName` arguments.
+  to `canCreate()`, and merges the `$name` and `$requestedName` arguments.
 
 - Plugin managers will now receive the parent service locator instead of itself
   in factories. In version 2.x, you needed to call the method
@@ -212,12 +221,20 @@ changes, outlined in this section.
   In practice, this should reduce code, as dependencies often come from the main
   service locator, and not the plugin manager itself.
 
+  To assist in migration, the method `getServiceLocator()` was added to `ServiceManager`
+  to ensure that existing factories continue to work; the method emits an `E_USER_DEPRECATED`
+  message to signal developers to update their factories.
+
 - `PluginManager` now enforces the need for the main service locator in its
   constructor. In v2.x, people often forgot to set the parent locator, which led
   to bugs in factories trying to fetch dependencies from the parent locator.
   Additionally, plugin managers now pull dependencies from the parent locator by
   default; if you need to pull a peer plugin, your factories will now need to
   pull the corresponding plugin manager first.
+
+  If you omit passing a service locator to the constructor, your plugin manager
+  will continue to work, but will emit a deprecation notice indicatin you
+  should update your initialization code.
 
 - It's so fast now that your app will fly!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,9 @@ changes, outlined in this section.
   enforced through the interface, that allows you to easily map multiple service
   names to the same factory.
 
+- The for `AbstractFactoryInterface` interface renames the method `canCreateServiceWithName()`
+  to `has()`, and merges the `$name` and `$requestedName` arguments.
+
 - Plugin managers will now receive the parent service locator instead of itself
   in factories. In version 2.x, you needed to call the method
   `getServiceLocator()` to retrieve the parent (application) service locator.

--- a/doc/book/configuring-the-service-manager.md
+++ b/doc/book/configuring-the-service-manager.md
@@ -170,7 +170,7 @@ implement `Zend\ServiceManager\Factory\AbstractFactoryInterface`:
 
 class MyAbstractFactory implements AbstractFactoryInterface
 {
-    public function canCreateServiceWithName(ContainerInterface $container, $requestedName)
+    public function has(ContainerInterface $container, $requestedName)
     {
         return in_array('Traversable', class_implements($requestedName), true);
     }
@@ -198,14 +198,14 @@ Here is what will happen:
    `A::class` service.
 2. Because none is found, it will process each abstract factory, in the order
    in which they were registered.
-3. It will call the `canCreateServiceWithName()` method, passing the service
-   manager instance and the name of the requested object. The method can use
-   any logic whatsoever to determine if it can create the service (such as
-   checking its name, checking for a required dependency in the passed
-   container, checking if a class implements a given interface, etc.).
-4. If `canCreateServiceWithName` returns `true`, it will call the `__invoke`
-   method to create the object. Otherwise, it will continue iterating the
-   abstract factories, until one matches, or the queue is exhausted.
+3. It will call the `has()` method, passing the service manager instance and
+   the name of the requested object. The method can use any logic whatsoever to
+   determine if it can create the service (such as checking its name, checking
+   for a required dependency in the passed container, checking if a class
+   implements a given interface, etc.).
+4. If `has` returns `true`, it will call the `__invoke` method to create the
+   object. Otherwise, it will continue iterating the abstract factories, until
+   one matches, or the queue is exhausted.
 
 ### Best practices
 

--- a/doc/book/configuring-the-service-manager.md
+++ b/doc/book/configuring-the-service-manager.md
@@ -170,7 +170,7 @@ implement `Zend\ServiceManager\Factory\AbstractFactoryInterface`:
 
 class MyAbstractFactory implements AbstractFactoryInterface
 {
-    public function has(ContainerInterface $container, $requestedName)
+    public function canCreate(ContainerInterface $container, $requestedName)
     {
         return in_array('Traversable', class_implements($requestedName), true);
     }
@@ -198,14 +198,14 @@ Here is what will happen:
    `A::class` service.
 2. Because none is found, it will process each abstract factory, in the order
    in which they were registered.
-3. It will call the `has()` method, passing the service manager instance and
+3. It will call the `canCreate()` method, passing the service manager instance and
    the name of the requested object. The method can use any logic whatsoever to
    determine if it can create the service (such as checking its name, checking
    for a required dependency in the passed container, checking if a class
    implements a given interface, etc.).
-4. If `has` returns `true`, it will call the `__invoke` method to create the
-   object. Otherwise, it will continue iterating the abstract factories, until
-   one matches, or the queue is exhausted.
+4. If `canCreate()` returns `true`, it will call the `__invoke` method to
+   create the object. Otherwise, it will continue iterating the abstract
+   factories, until one matches, or the queue is exhausted.
 
 ### Best practices
 

--- a/doc/book/migration.md
+++ b/doc/book/migration.md
@@ -329,17 +329,27 @@ configuration.
 
 ## Factories
 
-All factory interfaces were moved to a `Factory` subnamespace. Additionally, the
-signatures for all factories have changed.
+Internally, the `ServiceManager` now only uses the new factory interfaces
+defined in the `Zend\ServiceManager\Factory` namespace. These *replace* the
+interfaces defined in version 2, and define completely new signatures.
 
-### Removed and Renamed Factory Interfaces
+For migration purposes, all original interfaces were retained, and now inherit
+from the new interfaces. This provides a migration path; you can add the methods
+defined in the new interfaces to your existing factories targeting v2, and
+safely upgrade. (Typically, you will then have the version 2 methods proxy to
+those defined in version 3.)
 
-- `Zend\ServiceManager\AbstractFactoryInterface` was *renamed* to
-  `Zend\ServiceManager\Factory\AbstractFactoryInterface`.
-- `Zend\ServiceManager\DelegatorFactoryInterface` was *renamed* to
-  `Zend\ServiceManager\Factory\DelegatorFactoryInterface`.
-- `Zend\ServiceManager\FactoryInterface` was *renamed* to
-  `Zend\ServiceManager\Factory\FactoryInterface`.
+### Interfaces and relations to version 2
+
+| Version 2 Interface                                       | Version 3 Interface                                       |
+| :-------------------------------------------------------: | :-------------------------------------------------------: |
+| `Zend\ServiceManager\AbstractFactoryInterface`            | `Zend\ServiceManager\Factory\AbstractFactoryInterface`    |
+| `Zend\ServiceManager\DelegatorFactoryInterface`           | `Zend\ServiceManager\Factory\DelegatorFactoryInterface`   |
+| `Zend\ServiceManager\FactoryInterface`                    | `Zend\ServiceManager\Factory\FactoryInterface`            |
+
+The version 2 interfaces now extend those in version 3, but are marked
+**deprecated**. You can continue to use them, but will be required to update
+your code to use the new interfaces in the future.
 
 ### AbstractFactoryInterface
 
@@ -393,6 +403,94 @@ In v2, the abstract factory defined the method `canCreateServiceWithName()`; in
 v3, this is renamed to `canCreate()`, and the method also now receives only two
 arguments, the container and the requested service name.
 
+To prepare your version 2 implementation to work upon upgrade to version 3:
+
+- Add the methods `canCreate()` and `__invoke()` as defined in version 3.
+- Modify your existing `canCreateServiceWithName()` method to proxy to
+  `canCreate()`
+- Modify your existing `createServiceWithName()` method to proxy to
+  `__invoke()`
+
+As an example, given the following implementation from version 2:
+
+```php
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class LenientAbstractFactory implements AbstractFactoryInterface
+{
+    public function canCreateServiceWithName(ServiceLocatorInterface $services, $name, $requestedName)
+    {
+        return class_exists($requestedName);
+    }
+
+    public function createServiceWithName(ServiceLocatorInterface $services, $name, $requestedName)
+    {
+        return new $requestedName();
+    }
+}
+```
+
+To update this for version 3 compatibility, you will add the methods
+`canCreate()` and `__invoke()`, move the code from the existing methods into
+them, and update the existing methods to proxy to the new methods:
+
+```php
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class LenientAbstractFactory implements AbstractFactoryInterface
+{
+    public function canCreate(ContainerInterface $container, $requestedName)
+    {
+        return class_exists($requestedName);
+    }
+
+    public function canCreateServiceWithName(ServiceLocatorInterface $services, $name, $requestedName)
+    {
+        return $this->canCreate($services, $requestedName);
+    }
+
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        return new $requestedName();
+    }
+
+    public function createServiceWithName(ServiceLocatorInterface $services, $name, $requestedName)
+    {
+        return $this($services, $requestedName);
+    }
+}
+```
+
+After you have upgraded to version 3, you can take the following steps to remove
+the migration artifacts:
+
+- Update your class to implement the new interface.
+- Remove the `canCreateServiceWithName()` and `createServiceWithName()` methods
+  from your implementation.
+
+From our example above, we would update the class to read as follows:
+
+```php
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\AbstractFactoryInterface; // <-- note the change!
+
+class LenientAbstractFactory implements AbstractFactoryInterface
+{
+    public function canCreate(ContainerInterface $container, $requestedName)
+    {
+        return class_exists($requestedName);
+    }
+
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        return new $requestedName();
+    }
+}
+```
+
 ### DelegatorFactoryInterface
 
 The previous signature of the `DelegatorFactoryInterface` was:
@@ -435,6 +533,77 @@ interface DelegatorFactoryInterface
 Note that the `$name` and `$requestedName` arguments are now merged into a
 single `$name` argument, and that the factory now allows passing additional
 options to use (typically as passed via `build()`).
+
+To prepare your existing delegator factories for version 3, take the following
+steps:
+
+- Implement the `__invoke()` method in your existing factory, copying the code
+  from your existing `createDelegatorWithName()` method into it.
+- Modify the `createDelegatorWithName()` method to proxy to the new method.
+
+Consider the following delegator factory that works for version 2:
+
+```php
+use Zend\ServiceManager\DelegatorFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ObserverAttachmentDelegator implements DelegatorFactoryInterface
+{
+    public function createDelegatorWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName, $callback)
+    {
+        $subject = $callback();
+        $subject->attach($serviceLocator->get(Observer::class);
+        return $subject;
+    }
+}
+```
+
+To prepare this for version 3, we'd implement the `__invoke()` signature from
+version 3, and modify `createDelegatorWithName()` to proxy to it:
+
+```php
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\DelegatorFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ObserverAttachmentDelegator implements DelegatorFactoryInterface
+{
+    public function __invoke(ContainerInterface $container, $requestedName, callable $callback, array $options = null)
+    {
+        $subject = $callback();
+        $subject->attach($container->get(Observer::class);
+        return $subject;
+    }
+
+    public function createDelegatorWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName, $callback)
+    {
+        return $this($serviceLocator, $requestedName, $callback);
+    }
+}
+```
+
+After you have upgraded to version 3, you can take the following steps to remove
+the migration artifacts:
+
+- Update your class to implement the new interface.
+- Remove the `createDelegatorWithName()` method from your implementation.
+
+From our example above, we would update the class to read as follows:
+
+```php
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\DelegatorFactoryInterface; // <-- note the change!
+
+class ObserverAttachmentDelegator implements DelegatorFactoryInterface
+{
+    public function __invoke(ContainerInterface $container, $requestedName, callable $callback, array $options = null)
+    {
+        $subject = $callback();
+        $subject->attach($container->get(Observer::class);
+        return $subject;
+    }
+}
+```
 
 ### FactoryInterface
 
@@ -480,6 +649,90 @@ Because factories now can expect to receive the service name, they may be
 re-used for multiple services, largely replacing abstract factories in version
 3.
 
+To prepare your existing factories for version 3, take the following steps:
+
+- Implement the `__invoke()` method in your existing factory, copying the code
+  from your existing `createService()` method into it.
+- Modify the `createService()` method to proxy to the new method.
+
+Consider the following factory that works for version 2:
+
+```php
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FooFactory implements FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $services)
+    {
+        return new Foo($services->get(Bar::class));
+    }
+}
+```
+
+To prepare this for version 3, we'd implement the `__invoke()` signature from
+version 3, and modify `createService()` to proxy to it:
+
+```php
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FooFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        return new Foo($container->get(Bar::class));
+    }
+
+    public function createService(ServiceLocatorInterface $services)
+    {
+        return $this($services, Foo::class);
+    }
+}
+```
+
+Note that the call to `$this()` adds a new argument; since your factory isn't
+using the `$requestedName`, this can be anything, but must be passed to prevent
+a fatal exception due to a missing argument. In this case, we chose to pass the
+name of the class the factory is creating.
+
+After you have upgraded to version 3, you can take the following steps to remove
+the migration artifacts:
+
+- Update your class to implement the new interface.
+- Remove the `createService()` method from your implementation.
+
+From our example above, we would update the class to read as follows:
+
+```php
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\FactoryInterface; // <-- note the change!
+
+class FooFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        return new Foo($container->get(Bar::class));
+    }
+}
+```
+
+> #### Many factories already work with v3!
+>
+> Within the skeleton application, tutorial, and even in commonly shipped
+> modules such as those in Apigility, we have typically suggested building your
+> factories as invokable classes. If you were doing this already, your factories
+> will already work with version 3!
+
+> #### Version 2 factories can accept the requested name already
+>
+> Since 2.2, factories have been passed two additional parameters, the
+> "canonical" name (a mis-nomer, as it is actually the normalized name), and the
+> "requested" name (the actual string passed to `get()`). As such, you can
+> already write factories that accept the requested name, and have them
+> change behavior based on that information!
+
 ### New InvokableFactory Class
 
 `Zend\ServiceManager\Factory\InvokableFactory` is a new `FactoryInterface`
@@ -487,12 +740,23 @@ implementation that provides the capabilities of the "invokable classes" present
 in version 2. It essentially instantiates and returns the requested class name;
 if `$options` is non-empty, it passes them directly to the constructor.
 
+This class was [added to the version 2 tree](https://github.com/zendframework/zend-servicemanager/pull/60)
+to allow developers to start using it when preparing their code for version 3.
+This is particularly of interest when creating plugin managers, as you'll
+typically want the internal configuration to only include factories and aliases.
+
 ## Initializers
 
 Initializers are still present in the Service Manager component, but exist
 primarily for backwards compatibility; we recommend using delegator factories
 for setter and interface injection instead of initializers, as those will be run
 per-service, versus for all services.
+
+For migration purposes, the original interface was retained, and now inherits
+from the new interface. This provides a migration path; you can add the method
+defined in the new interface to your existing initializers targeting v2, and
+safely upgrade. (Typically, you will then have the version 2 method proxy to
+the one defined in version 3.)
 
 The following changes were made to initializers:
 
@@ -514,6 +778,130 @@ public function __invoke(ContainerInterface $container, $instance)
 
 The changes were made to ensure the signature is internally consistent with the
 various factories.
+
+To prepare your existing initializers for version 3, take the following steps:
+
+- Implement the `__invoke()` method in your existing factory, copying the code
+  from your existing `initialize()` method into it.
+- Modify the `initialize()` method to proxy to the new method.
+
+As an example, consider this initializer for version 2:
+
+```php
+use Zend\ServiceManager\InitializerInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FooInitializer implements InitializerInterface
+{
+    public function initializer($instance, ServiceLocatorInterface $services)
+    {
+        if (! $instance implements FooAwareInterface) {
+            return $instance;
+        }
+        $instance->setFoo($services->get(FooInterface::class);
+        return $instance;
+    }
+}
+```
+
+To prepare this for version 3, we'd implement the `__invoke()` signature from
+version 3, and modify `initialize()` to proxy to it:
+
+```php
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\InitializerInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FooInitializer implements InitializerInterface
+{
+    public function __invoke(ContainerInterface $container, $instance)
+    {
+        if (! $instance implements FooAwareInterface) {
+            return $instance;
+        }
+        $container->setFoo($services->get(FooInterface::class);
+        return $instance;
+    }
+
+    public function initializer($instance, ServiceLocatorInterface $services)
+    {
+        return $this($services, $instance);
+    }
+}
+```
+
+After you have upgraded to version 3, you can take the following steps to remove
+the migration artifacts:
+
+- Update your class to implement the new interface.
+- Remove the `initialize()` method from your implementation.
+
+From our example above, we would update the class to read as follows:
+
+```php
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Initializer\InitializerInterface; // <-- note the change!
+
+class FooInitializer implements InitializerInterface
+{
+    public function __invoke(ContainerInterface $container, $instance)
+    {
+        if (! $instance implements FooAwareInterface) {
+            return $instance;
+        }
+        $container->setFoo($services->get(FooInterface::class);
+        return $instance;
+    }
+}
+```
+
+> ### Update your callables!
+>
+> Version 2 allows you to provide initializers as PHP callables. However, this
+> means that the signature of those callables is incorrect for version 3!
+>
+> To make your code forwards compatible, you have two paths:
+>
+> The first is to simply provide an `InitializerInterface` implementation
+> instead. This guarantees that the correct method is called based on the
+> version of the `ServiceManager` in use.
+>
+> The second approach is to omit typehints on the arguments, and do typechecks
+> internally. As an example, let's say you have the following:
+>
+> ```php
+> $container->addInitializer(function ($instance, ContainerInterface $container) {
+>      if (! $instance implements FooAwareInterface) {
+>          return $instance;
+>      }
+>      $container->setFoo($services->get(FooInterface::class);
+>      return $instance;
+> });
+> ```
+>
+> To make this future-proof, remove the typehints, and check the types within
+> the callable:
+>
+> ```php
+> $container->addInitializer(function ($first, $second) {
+>      if ($first instanceof ContainerInterface) {
+>          $container = $first;
+>          $instance = $second;
+>      } else {
+>          $container = $second;
+>          $instance = $first;
+>      }
+>      if (! $instance implements FooAwareInterface) {
+>          return $instance;
+>      }
+>      $container->setFoo($services->get(FooInterface::class);
+>      return $instance;
+> });
+> ```
+>
+> This approach can also be done if you omitted typehints in the first place.
+> Regardless, the important part to remember is that order of arguments is
+> inverted between the two versions.
 
 ## Plugin Managers
 
@@ -733,6 +1121,128 @@ The `get()` method has new behavior:
   `ServiceManager`). To *never* cache instances, either set the
   `$sharedByDefault` class property to `false`, or pass a boolean `false` value
   via the `shared_by_default` configuration key.
+
+### Migration example
+
+Let's consider the following plugin manager geared towards version 2:
+
+```php
+use RuntimeException;
+use Zend\ServiceManager\AbstractPluginManager;
+
+class ObserverPluginManager extends AbstractPluginManager
+{
+    protected $invokables = [
+        'mail' => MailObserver::class,
+        'log' => LogObserver::class,
+    ];
+
+    public function validatePlugin($instance)
+    {
+        if (! $plugin instanceof ObserverInterface) {
+            throw new RuntimeException(sprintf(
+                'Invalid plugin "%s" created; not an instance of %s',
+                get_class($instance),
+                ObserverInterface::class
+            ));
+        }
+    }
+}
+```
+
+To prepare this for version 3, we need to do the following:
+
+- We need to change the `$invokables` configuration to a combination of
+  `factories` and `aliases`.
+- We need to implement a `validate()` method.
+- We need to update the `validatePlugin()` method to proxy to `validate()`.
+
+Doing so, we get the following result:
+
+```php
+use RuntimeException;
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Factory\InvokableFactory;
+
+class ObserverPluginManager extends AbstractPluginManager
+{
+    protected $instanceOf = ObserverInterface::class;
+
+    protected $aliases = [
+        'mail' => MailObserver::class,
+        'Mail' => MailObserver::class,
+        'log' => LogObserver::class,
+        'Log' => LogObserver::class,
+    ];
+
+    protected $factories = [
+        MailObserver::class => InvokableFactory::class,
+        LogObserver::class => InvokableFactory::class,
+    ];
+
+    public function validate($instance)
+    {
+        if (! $plugin instanceof $this->instanceOf) {
+            throw new RuntimeException(sprintf(
+                'Invalid plugin "%s" created; not an instance of %s',
+                get_class($instance),
+                $this->instanceOf
+            ));
+        }
+    }
+
+    public function validatePlugin($instance)
+    {
+        $this->validate($instance);
+    }
+}
+```
+
+Things to note about the above:
+
+- It introduces a new property, `$instanceOf`. We'll use this later, when we're
+  ready to clean up post-migration.
+- It introduces four aliases. This is to allow fetching the various plugins as
+  any of `mail`, `Mail`, `log`, or `Log` &mdash; all of which are valid in
+  version 2, but, because version 3 does not normalize names, need to be
+  explicitly aliased.
+- The aliases point to the fully qualified class name (FQCN) for the service
+  being generated, and these are mapped to `InvokableFactory` instances. This
+  means you can also fetch your plugins by their FQCN.
+
+The above will now work in both version 2 and version 3.
+
+After you migrate to version 3, you can clean up your plugin manager:
+
+- Remove the `validatePlugin()` method.
+- If your `validate()` routine is only checking that the instance is of a single
+  type, and has no other logic, you can remove that implementation as well, as
+  the `AbstractPluginManager` already takes care of that when `$instanceOf` is
+  defined!
+
+Performing these steps on the above, we get:
+
+```php
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Factory\InvokableFactory;
+
+class ObserverPluginManager extends AbstractPluginManager
+{
+    protected $instanceOf = ObserverInterface::class;
+
+    protected $aliases = [
+        'mail' => MailObserver::class,
+        'Mail' => MailObserver::class,
+        'log' => LogObserver::class,
+        'Log' => LogObserver::class,
+    ];
+
+    protected $factories = [
+        MailObserver::class => InvokableFactory::class,
+        LogObserver::class => InvokableFactory::class,
+    ];
+}
+```
 
 ## DI Namespace
 

--- a/doc/book/migration.md
+++ b/doc/book/migration.md
@@ -449,20 +449,22 @@ The new signature is:
 interface AbstractFactoryInterface extends FactoryInterface
 {
     /**
-     * Can we create an instance for the given service name?
+     * Does the factory have a way to create an instance for the service?
      *
      * @param  ContainerInterface $container
      * @param  string $requestedName
      * @return bool
      */
-    public function canCreateServiceWithName(ContainerInterface $container, $requestedName);
+    public function has(ContainerInterface $container, $requestedName);
 }
 ```
 
 Note that it now *extends* the `FactoryInterface` (detailed below), and thus the
-factory logic has the same signature. Additionally, note that the
-`canCreateServiceWithName()` now receives only two arguments, the container and
-the requested service name.
+factory logic has the same signature.
+
+In v2, the abstract factory defined the method `canCreateServiceWithName()`; in
+v3, this is renamed to `has()`, and the method also now receives only two
+arguments, the container and the requested service name.
 
 ### DelegatorFactoryInterface
 

--- a/src/AbstractFactoryInterface.php
+++ b/src/AbstractFactoryInterface.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager;
+
+/**
+ * Backwards-compatibility shim for AbstractFactoryInterface.
+ *
+ * Implementations should update to implement only Zend\ServiceManager\Factory\AbstractFactoryInterface.
+ *
+ * If upgrading from v2, take the following steps:
+ *
+ * - rename the method `canCreateServiceWithName()` to `has()`, and:
+ *   - rename the `$serviceLocator` argument to `$container`, and change the
+ *     typehint to `Interop\Container\ContainerInterface`
+ *   - merge the `$name` and `$requestedName` arguments
+ * - rename the method `createServiceWithName()` to `__invoke()`, and:
+ *   - rename the `$serviceLocator` argument to `$container`, and change the
+ *     typehint to `Interop\Container\ContainerInterface`
+ *   - merge the `$name` and `$requestedName` arguments
+ *   - add the optional `array $options = null` argument.
+ * - create a `canCreateServiceWithName()` method as defined in this interface, and have it
+ *   proxy to `has()`, passing `$requestedName` as the second argument.
+ * - create a `createServiceWithName()` method as defined in this interface, and have it
+ *   proxy to `__invoke()`, passing `$requestedName` as the second argument.
+ *
+ * Once you have tested your code, you can then update your class to only implement
+ * Zend\ServiceManager\Factory\AbstractFactoryInterface, and remove the `canCreateServiceWithName()`
+ * and `createServiceWithName()` methods.
+ *
+ * @deprecated Use Zend\ServiceManager\Factory\AbstractFactoryInterface instead.
+ */
+interface AbstractFactoryInterface extends Factory\AbstractFactoryInterface
+{
+    /**
+     * Determine if we can create a service with name
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @param $name
+     * @param $requestedName
+     * @return bool
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName);
+
+    /**
+     * Create service with name
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @param $name
+     * @param $requestedName
+     * @return mixed
+     */
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName);
+}

--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -93,6 +93,28 @@ abstract class AbstractPluginManager extends ServiceManager implements PluginMan
     }
 
     /**
+     * Override configure() to validate service instances.
+     *
+     * If an instance passed in the `services` configuration is invalid for the
+     * plugin manager, this method will raise an InvalidServiceException.
+     *
+     * {@inheritDoc}
+     * @throws InvalidServiceException
+     */
+    public function configure(array $config)
+    {
+        if (isset($config['services'])) {
+            foreach ($config['services'] as $service) {
+                $this->validate($service);
+            }
+        }
+
+        parent::configure($config);
+
+        return $this;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @param string $name Service name of plugin to retrieve.

--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -128,6 +128,15 @@ abstract class AbstractPluginManager extends ServiceManager implements PluginMan
      */
     public function validate($instance)
     {
+        if (method_exists($this, 'validatePlugin')) {
+            trigger_error(sprintf(
+                '%s::validatePlugin() has been deprecated as of 3.0; please define validate() instead',
+                get_class($this)
+            ), E_USER_DEPRECATED);
+            $this->validatePlugin($instance);
+            return;
+        }
+
         if (empty($this->instanceOf) || $instance instanceof $this->instanceOf) {
             return;
         }

--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -145,24 +145,6 @@ abstract class AbstractPluginManager extends ServiceManager implements PluginMan
      *
      * Returns the creation context.
      *
-     * @deprecated since 3.0.0. Factories using 3.0 should use the container
-     *     instance passed to the factory instead.
-     * @return ContainerInterface
-     */
-    public function getServiceLocator()
-    {
-        trigger_error(sprintf(
-            'Usage of %s is deprecated since v3.0.0; please use the container passed to the factory instead',
-            __METHOD__
-        ), E_USER_DEPRECATED);
-        return $this->creationContext;
-    }
-
-    /**
-     * Implemented for backwards compatibility only.
-     *
-     * Returns the creation context.
-     *
      * @deprecated since 3.0.0. The creation context should be passed during
      *     instantiation instead.
      * @param ContainerInterface $container

--- a/src/DelegatorFactoryInterface.php
+++ b/src/DelegatorFactoryInterface.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager;
+
+/**
+ * Backwards-compatibility shim for DelegatorFactoryInterface.
+ *
+ * Implementations should update to implement only Zend\ServiceManager\Factory\DelegatorFactoryInterface.
+ *
+ * If upgrading from v2, take the following steps:
+ *
+ * - rename the method `createDelegatorWithName()` to `__invoke()`, and:
+ *   - rename the `$serviceLocator` argument to `$container`, and change the
+ *     typehint to `Interop\Container\ContainerInterface`
+ *   - merge the `$name` and `$requestedName` arguments
+ *   - add the `callable` typehint to the `$callback` argument
+ *   - add the optional `array $options = null` argument as a final argument
+ * - create a `createDelegatorWithName()` method as defined in this interface, and have it
+ *   proxy to `__invoke()`, passing `$requestedName` as the second argument.
+ *
+ * Once you have tested your code, you can then update your class to only implement
+ * Zend\ServiceManager\Factory\DelegatorFactoryInterface, and remove the `createDelegatorWithName()`
+ * method.
+ *
+ * @deprecated Use Zend\ServiceManager\Factory\DelegatorFactoryInterface instead.
+ */
+interface DelegatorFactoryInterface extends Factory\DelegatorFactoryInterface
+{
+    /**
+     * A factory that creates delegates of a given service
+     *
+     * @param ServiceLocatorInterface $serviceLocator the service locator which requested the service
+     * @param string                  $name           the normalized service name
+     * @param string                  $requestedName  the requested service name
+     * @param callable                $callback       the callback that is responsible for creating the service
+     *
+     * @return mixed
+     */
+    public function createDelegatorWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName, $callback);
+}

--- a/src/Factory/AbstractFactoryInterface.php
+++ b/src/Factory/AbstractFactoryInterface.php
@@ -15,8 +15,8 @@ use Interop\Container\ContainerInterface;
  * Interface for an abstract factory.
  *
  * An abstract factory extends the factory interface, but also has an
- * additional "canCreateService" method, which is called to check if the
- * abstract factory can create an instance for the given service. You should
+ * additional "has" method, which is called to check if the abstract factory
+ * has the ability to create an instance for the given service. You should
  * limit the number of abstract factories to ensure good performance. Starting
  * from ServiceManager v3, remember that you can also attach multiple names to
  * the same factory, which reduces the need for abstract factories.
@@ -30,5 +30,5 @@ interface AbstractFactoryInterface extends FactoryInterface
      * @param  string $requestedName
      * @return bool
      */
-    public function canCreateServiceWithName(ContainerInterface $container, $requestedName);
+    public function canCreate(ContainerInterface $container, $requestedName);
 }

--- a/src/FactoryInterface.php
+++ b/src/FactoryInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager;
+
+/**
+ * Backwards-compatibility shim for FactoryInterface.
+ *
+ * Implementations should update to implement only Zend\ServiceManager\Factory\FactoryInterface.
+ *
+ * If upgrading from v2, take the following steps:
+ *
+ * - rename the method `createService()` to `__invoke()`, and:
+ *   - rename the `$serviceLocator` argument to `$container`, and change the
+ *     typehint to `Interop\Container\ContainerInterface`
+ *   - add the `$requestedName` as a second argument
+ *   - add the optional `array $options = null` argument as a final argument
+ * - create a `createService()` method as defined in this interface, and have it
+ *   proxy to `__invoke()`.
+ *
+ * Once you have tested your code, you can then update your class to only implement
+ * Zend\ServiceManager\Factory\FactoryInterface, and remove the `createService()`
+ * method.
+ *
+ * @deprecated Use Zend\ServiceManager\Factory\FactoryInterface instead.
+ */
+interface FactoryInterface extends Factory\FactoryInterface
+{
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return mixed
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator);
+}

--- a/src/InitializerInterface.php
+++ b/src/InitializerInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager;
+
+/**
+ * Backwards-compatibility shim for InitializerInterface.
+ *
+ * Implementations should update to implement only Zend\ServiceManager\Initializer\InitializerInterface.
+ *
+ * If upgrading from v2, take the following steps:
+ *
+ * - rename the method `initializer()` to `__invoke()`, and:
+ *   - rename the `$serviceLocator` argument to `$container`, and change the
+ *     typehint to `Interop\Container\ContainerInterface`
+ *   - swap the order of the arguments (so that `$instance` comes second)
+ * - create an `initializer()` method as defined in this interface, and have it
+ *   proxy to `__invoke()`, passing the arguments in the new order.
+ *
+ * Once you have tested your code, you can then update your class to only implement
+ * Zend\ServiceManager\Initializer\InitializerInterface, and remove the `initialize()`
+ * method.
+ *
+ * @deprecated Use Zend\ServiceManager\Initializer\InitializerInterface instead.
+ */
+interface InitializerInterface extends Initializer\InitializerInterface
+{
+    /**
+     * Initialize
+     *
+     * @param $instance
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return mixed
+     */
+    public function initialize($instance, ServiceLocatorInterface $serviceLocator);
+}

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -210,7 +210,7 @@ class ServiceManager implements ServiceLocatorInterface
 
         // Check abstract factories
         foreach ($this->abstractFactories as $abstractFactory) {
-            if ($abstractFactory->canCreateServiceWithName($this, $name)) {
+            if ($abstractFactory->canCreate($this, $name)) {
                 return true;
             }
         }
@@ -590,7 +590,7 @@ class ServiceManager implements ServiceLocatorInterface
 
         // Check abstract factories
         foreach ($this->abstractFactories as $abstractFactory) {
-            if ($abstractFactory->canCreateServiceWithName($this, $name)) {
+            if ($abstractFactory->canCreate($this, $name)) {
                 return $abstractFactory;
             }
         }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -141,6 +141,24 @@ class ServiceManager implements ServiceLocatorInterface
     }
 
     /**
+     * Implemented for backwards compatibility with previous plugin managers only.
+     *
+     * Returns the creation context.
+     *
+     * @deprecated since 3.0.0. Factories using 3.0 should use the container
+     *     instance passed to the factory instead.
+     * @return ContainerInterface
+     */
+    public function getServiceLocator()
+    {
+        trigger_error(sprintf(
+            'Usage of %s is deprecated since v3.0.0; please use the container passed to the factory instead',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+        return $this->creationContext;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function get($name)

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -333,4 +333,20 @@ class AbstractPluginManagerTest extends TestCase
         $this->assertTrue($assertionCalled, 'Assertion was not called by validatePlugin!');
         $this->assertTrue($errorHandlerCalled, 'Error handler was not triggered by validatePlugin!');
     }
+
+    public function testSetServiceShouldRaiseExceptionForInvalidPlugin()
+    {
+        $pluginManager = new TestAsset\SimplePluginManager(new ServiceManager());
+        $this->setExpectedException(InvalidServiceException::class);
+        $pluginManager->setService(stdClass::class, new stdClass());
+    }
+
+    public function testPassingServiceInstanceViaConfigureShouldRaiseExceptionForInvalidPlugin()
+    {
+        $pluginManager = new TestAsset\SimplePluginManager(new ServiceManager());
+        $this->setExpectedException(InvalidServiceException::class);
+        $pluginManager->configure(['services' => [
+            stdClass::class => new stdClass(),
+        ]]);
+    }
 }

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -183,19 +183,6 @@ class AbstractPluginManagerTest extends TestCase
     /**
      * @group migration
      */
-    public function testCanRetrieveParentContainerViaGetServiceLocatorWithDeprecationNotice()
-    {
-        $container = $this->createContainer();
-        set_error_handler(function ($errno, $errstr) {
-            $this->assertEquals(E_USER_DEPRECATED, $errno);
-        }, E_USER_DEPRECATED);
-        $this->assertSame($this->creationContext, $container->getServiceLocator());
-        restore_error_handler();
-    }
-
-    /**
-     * @group migration
-     */
     public function testCallingSetServiceLocatorSetsCreationContextWithDeprecationNotice()
     {
         set_error_handler(function ($errno, $errstr) {

--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -770,4 +770,17 @@ trait CommonServiceLocatorBehaviorsTrait
         $container->setAllowOverride(true);
         $this->assertTrue($container->getAllowOverride());
     }
+
+    /**
+     * @group migration
+     */
+    public function testCanRetrieveParentContainerViaGetServiceLocatorWithDeprecationNotice()
+    {
+        $container = $this->createContainer();
+        set_error_handler(function ($errno, $errstr) {
+            $this->assertEquals(E_USER_DEPRECATED, $errno);
+        }, E_USER_DEPRECATED);
+        $this->assertSame($this->creationContext, $container->getServiceLocator());
+        restore_error_handler();
+    }
 }

--- a/test/TestAsset/FailingAbstractFactory.php
+++ b/test/TestAsset/FailingAbstractFactory.php
@@ -17,7 +17,7 @@ class FailingAbstractFactory implements AbstractFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function canCreateServiceWithName(ContainerInterface $container, $name)
+    public function canCreate(ContainerInterface $container, $name)
     {
         return false;
     }

--- a/test/TestAsset/NonAutoInvokablePluginManager.php
+++ b/test/TestAsset/NonAutoInvokablePluginManager.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Zend\ServiceManager\AbstractPluginManager;
+
+class NonAutoInvokablePluginManager extends AbstractPluginManager
+{
+    protected $autoAddInvokableClass = false;
+    protected $instanceOf = InvokableObject::class;
+}

--- a/test/TestAsset/SimpleAbstractFactory.php
+++ b/test/TestAsset/SimpleAbstractFactory.php
@@ -17,7 +17,7 @@ class SimpleAbstractFactory implements AbstractFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function canCreateServiceWithName(ContainerInterface $container, $name)
+    public function canCreate(ContainerInterface $container, $name)
     {
         return true;
     }

--- a/test/TestAsset/V2ValidationPluginManager.php
+++ b/test/TestAsset/V2ValidationPluginManager.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use RuntimeException;
+use Zend\ServiceManager\AbstractPluginManager;
+
+class V2ValidationPluginManager extends AbstractPluginManager
+{
+    public $assertion;
+
+    public function validatePlugin($plugin)
+    {
+        if (! is_callable($this->assertion)) {
+            throw new RuntimeException(sprintf(
+                '%s requires a callable $assertion property; not currently set',
+                __CLASS__
+            ));
+        }
+
+        call_user_func($this->assertion, $plugin);
+    }
+}


### PR DESCRIPTION
This patch provides a number of features to allow us to provide forwards compatibilty in v2, as well as backwards compatibility with v2 code.

## AbstractFactoryInterface

This patch renames the `canCreateServiceWithName()` method to `canCreate()`.  This ensures there are no overlapping methods between the v2 and v3 interfaces.

## Re-introduction of v2 interfaces

The v3 factory and initializer interfaces were all pushed under new namespaces, and, as such, have zero overlap with the existing v2 interfaces. However, the v2 interfaces cannot be used currently with v3, meaning any factories or initializers that implemented the interfaces (vs using callables) are de facto incompatible with v3.

This patch reintroduces the v2 interfaces, and modifies them to inherit from the v3 interfaces. This provides a forwards compatibility feature: developers can implement the new methods from the v3 interfaces in their existing v2 code, and thus ensure that their factories and initializers will continue to work on upgrading to v3.

As an example, consider the following factory implementation for v2:

```php
use Zend\ServiceManager\FactoryInterface;
use Zend\ServiceManager\ServiceLocatorInterface;

class SomethingFactory implements FactoryInterface
{
    public function createService(ServiceLocatorInterface $services)
    {
        return new Something($services->get('SomethingElse'));
    }
}
```

To prepare this for v3 compatibility, you could do the following:

```php
use Interop\Container\ContainerInterface;
use Zend\ServiceManager\FactoryInterface;
use Zend\ServiceManager\ServiceLocatorInterface;

class SomethingFactory implements FactoryInterface
{
    public function createService(ServiceLocatorInterface $services)
    {
        return $this($services, 'Something');
    }

    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
    {
        return new Something($container->get('SomethingElse'));
    }
}
```

In v2, `createService()` will be called, and proxy to `__invoke()`; on an upgrade to v3, only `__invoke()` will be called. Developers can then later update the factory to read as the following:

```php
use Interop\Container\ContainerInterface;
use Zend\ServiceManager\Factory\FactoryInterface;

class SomethingFactory implements FactoryInterface
{
    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
    {
        return new Something($container->get('SomethingElse'));
    }
}
```

The re-introduced interfaces include:

- `Zend\ServiceManager\AbstractFactoryInterface` (extends `Zend\ServiceManager\Factory\AbstractFactoryInterface`)
- `Zend\ServiceManager\DelegatorFactoryInterface` (extends `Zend\ServiceManager\Factory\DelegatorFactoryInterface`)
- `Zend\ServiceManager\FactoryInterface` (extends `Zend\ServiceManager\Factory\FactoryInterface`)
- `Zend\ServiceManager\InitializerInterface` (extends `Zend\ServiceManager\Initializer\InitializerInterface`)

## AbstractPluginManager

The `AbstractPluginManager` suffered a number of BC breaks, and this patch attempts to address each of them.

First, the `$autoAddInvokableClass` flag was re-introduced, along with its behavior. This allows fetching a class by FQCN from a plugin manager, without it first being registered. As plugin managers include instance validation, this is a safe operation.

Second, the `validate()` method was updated to perform a check for a `validatePlugin()` method, which was an `abstract` method defined in v2. If present, the `validate()` method will proxy to it, after first raising an `E_USER_DEPRECATED` notice prompting the user to rename the method.

Third, the constructor was updated to allow overloading of the first argument.  In v2, the constructor expects a null or `ConfigInterface` first argument, and many tests and factories already exist that operate on this assumption. As such, the constructor now supports the following combinations, with the associated behavior:

- A single `ContainerInterface` argument (v3 behavior); sets the `$creationContext` to the argument.
- A `ContainerInterface` argument and an array of configuration (v3 behavior); sets the `$creationContext` to the first argument, and uses the second to configure the plugin manager instance.
- No arguments (v2 behavior); sets the `$creationContext` to the plugin manager instance, but raises an `E_USER_DEPRECATED` notice.
- A `ConfigInterface` first argument (v2 behavior); uses the argument to configure the plugin manager, sets the `$creationContext` to the plugin manager, and raises deprecation notices for both conditions.

Additionally, similar changes were proposed for v2 in #60, ensuring a migration path for users.

Fourth, the `setServiceLocator()` and `getServiceLocator()` methods were reintroduced, though without the related `ServiceLocatorAwareInterface`. This was done as follows:

- `AbstractPluginManager` now defines `setServiceLocator()`, and uses it to set the `$creationContext`, but raises an `E_USER_DEPRECATED` notice when doing so. This is done to facilitate existing tests and plugin manager factories.
- `ServiceManager` (from which `AbstractPluginManager` inherits) defines `getServiceLocator()`, and returns the `$creationContext`, while raising an `E_USER_DEPRECATED` notice.

This latter change requires explanation. Essentially, many plugin factories look like the following:

```php
function ($plugins)
{
    $services = $plugins->getServiceLocator();
    return new Plugin($services->get('SomeDependency'));
}
```

In v3, the first argument passed to a factory is actually the parent locator/creation context, analagous to `$services` in the above example. In order to ensure that existing factories will continue to work, we had to add the `getServiceLocator()` method to the `ServiceManager`, as it will generally be an instance of that class being passed to the factory. This makes the call redundant, but ensures it continues to work. By raising the deprecation notice, we can signal developers to upgrade their factories.

## Documentation

The migration documentation has been updated to reflect these changes, highlighting how to prepare v2 code to work under v3.
