### PR TITLE
Forwards-compatibility changes

### DIFF
--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -9,6 +9,7 @@
 
 namespace Zend\ServiceManager;
 
+use Interop\Container\ContainerInterface;
 use Exception as BaseException;
 
 /**
@@ -57,11 +58,56 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
      * Add a default initializer to ensure the plugin is valid after instance
      * creation.
      *
-     * @param null|ConfigInterface $configuration
+     * Additionally, the constructor provides forwards compatibility with v3 by
+     * overloading the initial argument. v2 usage expects either null or a
+     * ConfigInterface instance, and will ignore any other arguments. v3 expects
+     * a ContainerInterface instance, and will use an array of configuration to
+     * seed the current instance with services. In most cases, you can ignore the
+     * constructor unless you are writing a specialized factory for your plugin
+     * manager or overriding it.
+     *
+     * @param null|ConfigInterface|ContainerInterface $configOrContainerInstance
+     * @param array $v3config If $configOrContainerInstance is a container, this
+     *     value will be passed to the parent constructor.
+     * @throws Exception\InvalidArgumentException if $configOrContainerInstance
+     *     is neither null, nor a ConfigInterface, nor a ContainerInterface.
      */
-    public function __construct(ConfigInterface $configuration = null)
+    public function __construct($configOrContainerInstance = null, array $v3config = [])
     {
-        parent::__construct($configuration);
+        if (null !== $configOrContainerInstance
+            && ! $configOrContainerInstance instanceof ConfigInterface
+            && ! $configOrContainerInstance instanceof ContainerInterface
+        ) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects a ConfigInterface instance or ContainerInterface instance; received %s',
+                get_class($this),
+                (is_object($configOrContainerInstance)
+                    ? get_class($configOrContainerInstance)
+                    : gettype($configOrContainerInstance)
+                )
+            ));
+        }
+
+        if ($configOrContainerInstance instanceof ContainerInterface) {
+            if (property_exists($this, 'serviceLocator')) {
+                if (! empty($v3config)) {
+                    parent::__construct(new Config($v3config));
+                }
+                $this->serviceLocator = $configOrContainerInstance;
+            }
+
+            if (property_exists($this, 'creationContext')) {
+                if (! empty($v3config)) {
+                    parent::__construct($v3config);
+                }
+                $this->creationContext = $configOrContainerInstance;
+            }
+        }
+
+        if ($configOrContainerInstance instanceof ConfigInterface) {
+            parent::__construct($configOrContainerInstance);
+        }
+
         $this->addInitializer(function ($instance) {
             if ($instance instanceof ServiceLocatorAwareInterface) {
                 $instance->setServiceLocator($this);

--- a/src/Factory/InvokableFactory.php
+++ b/src/Factory/InvokableFactory.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager\Factory;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Exception\InvalidServiceNameException;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Factory for instantiating classes with no dependencies or which accept a single array.
+ *
+ * The InvokableFactory can be used for any class that:
+ *
+ * - has no constructor arguments;
+ * - accepts a single array of arguments via the constructor.
+ *
+ * It replaces the "invokables" and "invokable class" functionality of the v2
+ * service manager, and can also be used in v2 code for forwards compatibility
+ * with v3.
+ */
+final class InvokableFactory implements FactoryInterface
+{
+    /**
+     * Create an instance of the requested class name.
+     *
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     * @return object
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        return (null === $options) ? new $requestedName : new $requestedName($options);
+    }
+
+    /**
+     * Create an instance of the named service.
+     *
+     * If `$requestedName` is not provided, raises an exception; otherwise,
+     * proxies to the `__invoke()` method to create an instance of the
+     * requested class.
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @param null|string $canonicalName Ignored
+     * @param null|string $requestedName
+     * @return object
+     * @throws InvalidServiceNameException
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator, $canonicalName = null, $requestedName = null)
+    {
+        if (! $requestedName) {
+            throw new InvalidServiceNameException(sprintf(
+                '%s requires that the requested name is provided on invocation; please update your tests or consuming container',
+                __CLASS__
+            ));
+        }
+        return $this($serviceLocator, $requestedName);
+    }
+}

--- a/test/Factory/InvokableFactoryTest.php
+++ b/test/Factory/InvokableFactoryTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\Factory;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ServiceManager\Factory\InvokableFactory;
+use ZendTest\ServiceManager\TestAsset\InvokableObject;
+
+/**
+ * @covers \Zend\ServiceManager\Factory\InvokableFactory
+ */
+class InvokableFactoryTest extends TestCase
+{
+    public function testCanCreateObject()
+    {
+        $container = $this->getMock(ContainerInterface::class);
+        $factory   = new InvokableFactory();
+
+        $object = $factory($container, InvokableObject::class, ['foo' => 'bar']);
+
+        $this->assertInstanceOf(InvokableObject::class, $object);
+        $this->assertEquals(['foo' => 'bar'], $object->options);
+    }
+}

--- a/test/TestAsset/InvokableObject.php
+++ b/test/TestAsset/InvokableObject.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+class InvokableObject
+{
+    /**
+     * @var array
+     */
+    public $options;
+
+    /**
+     * @param array $options
+     */
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+}


### PR DESCRIPTION
This patch provides forwards compatibility features for the v2 series to allow users to update their code for use with v3 prior to an actual migration.

## AbstractPluginManager

This patch modifies the `AbstractPluginManager` constructor to allow the following combination of arguments:

- No arguments (current behavior).
- Single `ConfigInterface` argument (current behavior); used to configure the instance.
- Single `ContainerInterface` argument (v3 behavior); sets the "parent" locator/"creation context"
- `ContainerInterface` as first argument, array as second (v3 behavior); sets the "parent" locator/"creation context", and uses the second argument to configure the instance.

These changes allow developers the ability to continue to use existing plugin managers when upgrading to v3 (though they will also need to implement a `validate()` method, which will be in the migration guide).

The changes presented are backwards compatible (loosens typehint on initial argument; new, second argument is optional), and are based on changes being implemented in #59.

## InvokableFactory

The `InvokableFactory` introduced in the develop branch is compatible with v2 as well, and this patch adapts it for use with v2. This will allow existing component refactors to retain changes that introduce the `InvokableFactory` + aliases.