### PR TITLE
InvokableFactory behavior for v2 series

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
 
 install:
-  - travis_retry composer install --no-interaction --ignore-platform-reqs
+  - COMPOSER_ROOT_VERSION=2.7.99 travis_retry composer install --no-interaction --ignore-platform-reqs
 
 script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi

--- a/src/Exception/InvalidServiceException.php
+++ b/src/Exception/InvalidServiceException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager\Exception;
+
+class InvalidServiceException extends RuntimeException
+{
+}

--- a/src/Factory/InvokableFactory.php
+++ b/src/Factory/InvokableFactory.php
@@ -52,13 +52,14 @@ final class InvokableFactory implements FactoryInterface
      *
      * Finally, if the above each fail, it raises an exception.
      *
-     * The approach above is perfomed as version 2 has two distinct behaviors
+     * The approach above is performed as version 2 has two distinct behaviors
      * under which factories are invoked:
      *
      * - If an alias was used, $canonicalName is the resolved name, and
-     *   $requestedName is the service name requested;
+     *   $requestedName is the service name requested, in which case $canonicalName
+     *   is likely the qualified class name;
      * - Otherwise, $canonicalName is the normalized name, and $requestedName
-     *   is the original service name requested (typically a class name).
+     *   is the original service name requested (typically the qualified class name).
      *
      * @param ServiceLocatorInterface $serviceLocator
      * @param null|string $canonicalName

--- a/src/Factory/InvokableFactory.php
+++ b/src/Factory/InvokableFactory.php
@@ -10,7 +10,7 @@
 namespace Zend\ServiceManager\Factory;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Exception\InvalidServiceNameException;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -64,7 +64,7 @@ final class InvokableFactory implements FactoryInterface
      * @param null|string $canonicalName
      * @param null|string $requestedName
      * @return object
-     * @throws InvalidServiceNameException
+     * @throws InvalidServiceException
      */
     public function createService(ServiceLocatorInterface $serviceLocator, $canonicalName = null, $requestedName = null)
     {
@@ -76,7 +76,7 @@ final class InvokableFactory implements FactoryInterface
             return $this($serviceLocator, $requestedName);
         }
 
-        throw new InvalidServiceNameException(sprintf(
+        throw new InvalidServiceException(sprintf(
             '%s requires that the requested name is provided on invocation; please update your tests or consuming container',
             __CLASS__
         ));

--- a/test/Factory/InvokableFactoryTest.php
+++ b/test/Factory/InvokableFactoryTest.php
@@ -11,7 +11,7 @@ namespace ZendTest\ServiceManager\Factory;
 
 use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\ServiceManager\Exception\InvalidServiceNameException;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\ServiceManager\ServiceManager;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
@@ -57,7 +57,7 @@ class InvokableFactoryTest extends TestCase
         $container = new ServiceManager();
         $factory   = new InvokableFactory();
 
-        $this->setExpectedException(InvalidServiceNameException::class);
+        $this->setExpectedException(InvalidServiceException::class);
         $object = $factory->createService($container, 'invokableobject', 'invokableobject');
     }
 }

--- a/test/Factory/InvokableFactoryTest.php
+++ b/test/Factory/InvokableFactoryTest.php
@@ -11,7 +11,9 @@ namespace ZendTest\ServiceManager\Factory;
 
 use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ServiceManager\Exception\InvalidServiceNameException;
 use Zend\ServiceManager\Factory\InvokableFactory;
+use Zend\ServiceManager\ServiceManager;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 
 /**
@@ -19,7 +21,7 @@ use ZendTest\ServiceManager\TestAsset\InvokableObject;
  */
 class InvokableFactoryTest extends TestCase
 {
-    public function testCanCreateObject()
+    public function testCanCreateObjectWhenInvokedUsingProvidedOptions()
     {
         $container = $this->getMock(ContainerInterface::class);
         $factory   = new InvokableFactory();
@@ -28,5 +30,34 @@ class InvokableFactoryTest extends TestCase
 
         $this->assertInstanceOf(InvokableObject::class, $object);
         $this->assertEquals(['foo' => 'bar'], $object->options);
+    }
+
+    public function testCanCreateObjectViaCreateServiceWhenCanonicalNameIsNormalizedNameAndRequestedNameIsQualified()
+    {
+        $container = new ServiceManager();
+        $factory   = new InvokableFactory();
+
+        $object = $factory->createService($container, 'invokableobject', InvokableObject::class);
+
+        $this->assertInstanceOf(InvokableObject::class, $object);
+    }
+
+    public function testCanCreateObjectViaCreateServiceWhenCanonicalNameIsQualified()
+    {
+        $container = new ServiceManager();
+        $factory   = new InvokableFactory();
+
+        $object = $factory->createService($container, InvokableObject::class, 'invokableobject');
+
+        $this->assertInstanceOf(InvokableObject::class, $object);
+    }
+
+    public function testRaisesExceptionIfNeitherCanonicalNorRequestedNameAreQualified()
+    {
+        $container = new ServiceManager();
+        $factory   = new InvokableFactory();
+
+        $this->setExpectedException(InvalidServiceNameException::class);
+        $object = $factory->createService($container, 'invokableobject', 'invokableobject');
     }
 }


### PR DESCRIPTION
This patch provides a couple of fixes for behavior/incompatibilities observed in the v2 series when adapting existing components to work against both v2 and v3:

- First, it adds `InvalidServiceException`. This particular exception exists on v3, but not v2, and is thrown by the v3 implementation of `InvokableFactory`. As such, v2 requires it.
- Second, it alters the behavior of `InvokableFactory::createService()` to accommodate the two possible behaviors that exist in v2 (but not v3):
  - The original behavior, in which a `name => factory` configuration is used, results in `$canonicalName` being a normalized name, and `$requestedName` being the name as passed to `get()` — which would be the class name to use.
  - In v2, if an alias was used, `$canonicalName` is the *resolved alias*, which will be the *qualified class name*. As such, this patch introduces a check to see if `$canonicalName` is an existing class name, and, if so, it uses that name when calling `__invoke()`.