### PR TITLE
Allow creation options as passed via v2 factories.

### DIFF
--- a/test/Factory/InvokableFactoryTest.php
+++ b/test/Factory/InvokableFactoryTest.php
@@ -60,4 +60,15 @@ class InvokableFactoryTest extends TestCase
         $this->setExpectedException(InvalidServiceException::class);
         $object = $factory->createService($container, 'invokableobject', 'invokableobject');
     }
+
+    public function testCreateServiceCanCreateObjectWithCreationOptionsProvidedToConstructor()
+    {
+        $container = new ServiceManager();
+        $factory   = new InvokableFactory(['foo' => 'bar']);
+
+        $object = $factory->createService($container, InvokableObject::class);
+
+        $this->assertInstanceOf(InvokableObject::class, $object);
+        $this->assertEquals(['foo' => 'bar'], $object->options);
+    }
 }


### PR DESCRIPTION
In v2, options passed via the second argument to `AbstractPluginManager::get()` are passed to factory *constructors*; the factory must then determine whether or not to use them when creating the object instance.

This patch updates `InvokableFactory` to add a constructor that can accept creation arguments; `createService()` will then pass them to `__invoke()` when present.