### PR TITLE
Broken use case using Alias of Alias

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -477,7 +477,7 @@ class ServiceManager implements ServiceLocatorInterface, ContainerInterface
             }
 
             $stack[$cName] = $cName;
-            $cName = $this->aliases[$cName];
+            $cName = $this->aliases[$this->canonicalizeName($cName)];
         }
 
         return $cName;

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -248,6 +248,17 @@ class ServiceManagerTest extends TestCase
     /**
      * @covers Zend\ServiceManager\ServiceManager::get
      */
+    public function testGetWithAliasofAliasWithCanonicalizedName()
+    {
+        $this->serviceManager->setService('Foo', 'Bar');
+        $this->serviceManager->setAlias('Baz', 'Foo');
+        $this->serviceManager->setAlias('Qux', 'Baz');
+        $this->assertEquals('Bar', $this->serviceManager->get('Qux'));
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::get
+     */
     public function testGetAbstractFactoryWithAlias()
     {
         $expected = new TestAsset\Foo;


### PR DESCRIPTION
Release 2.7.3 broke a use case of Alias of Alias without using an already canonicalized name.

Added a test that recreates the problem, and I think a fix that doesn't seem to break any other tests and achieves what I hope is the right thing. 

All comments welcome, but we'd appreciate getting a fix on this soon.

Thanks