### PR TITLE
require zend-stdlib in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
-        "container-interop/container-interop": "~1.0"
+        "container-interop/container-interop": "~1.0",
+        "zendframework/zend-stdlib": "~2.7"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.6",


### PR DESCRIPTION
As reported in issue https://github.com/zendframework/zend-servicemanager/issues/73 library `zendframework/zend-stdlib` should be required.