### PR TITLE
service can be a Closure

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -403,6 +403,10 @@ class ServiceManager implements ServiceLocatorInterface, ContainerInterface
             $this->unregisterService($cName);
         }
 
+        if($service instanceof \Closure) {
+            $service = $service();
+        }
+
         $this->instances[$cName] = $service;
 
         return $this;


### PR DESCRIPTION
`ServiceManager::setService($name, $service)` should allow the usage of Closures... Should it not?

In Zend-Expressive, adding a service with a closure results in a Fatal Error.

```php
// /config/autoload/services.global.php

use Zend\Authentication\AuthenticationService;
use Zend\Authentication\Storage\Session;
use Zend\Authentication\Adapter\DbTable;

return [
    'dependencies' => [
        'services' => [
            AuthenticationService::class => function() {
                return new AuthenticationService(new Session(/*...*/), new DbTable(/*...*/));
            }
        ]
    ]
]
```

Or is this dumb?
