### PR TITLE
Fixed creationContext not being passed to abstract factory canCreate()

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -228,7 +228,7 @@ class ServiceManager implements ServiceLocatorInterface
 
         // Check abstract factories
         foreach ($this->abstractFactories as $abstractFactory) {
-            if ($abstractFactory->canCreate($this, $name)) {
+            if ($abstractFactory->canCreate($this->creationContext, $name)) {
                 return true;
             }
         }
@@ -608,7 +608,7 @@ class ServiceManager implements ServiceLocatorInterface
 
         // Check abstract factories
         foreach ($this->abstractFactories as $abstractFactory) {
-            if ($abstractFactory->canCreate($this, $name)) {
+            if ($abstractFactory->canCreate($this->creationContext, $name)) {
                 return $abstractFactory;
             }
         }

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -16,6 +16,7 @@ use Zend\ServiceManager\ConfigInterface;
 use Zend\ServiceManager\Exception\InvalidArgumentException;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
+use Zend\ServiceManager\Factory\AbstractFactoryInterface;
 use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\ServiceManager\ServiceManager;
@@ -348,5 +349,18 @@ class AbstractPluginManagerTest extends TestCase
         $pluginManager->configure(['services' => [
             stdClass::class => new stdClass(),
         ]]);
+    }
+
+    public function testAbstractFactoryGetsCreationContext()
+    {
+        $serviceManager = new ServiceManager();
+        $pluginManager = new TestAsset\SimplePluginManager($serviceManager);
+        $abstractFactory = $this->prophesize(AbstractFactoryInterface::class);
+        $abstractFactory->canCreate($serviceManager, 'foo')
+            ->willReturn(true);
+        $abstractFactory->__invoke($serviceManager, 'foo', null)
+            ->willReturn(new InvokableObject());
+        $pluginManager->addAbstractFactory($abstractFactory->reveal());
+        $this->assertInstanceOf(InvokableObject::class, $pluginManager->get('foo'));
     }
 }


### PR DESCRIPTION
Fix for #78 