### PR TITLE
Test for v2-v3 PluginManager migration

### DIFF
--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -17,7 +17,9 @@ use Zend\ServiceManager\Exception\InvalidArgumentException;
 use Zend\ServiceManager\Exception\RuntimeException;
 use Zend\ServiceManager\ServiceManager;
 use ZendTest\ServiceManager\TestAsset\FooPluginManager;
+use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\MockSelfReturningDelegatorFactory;
+use ZendTest\ServiceManager\TestAsset\V2v3PluginManager;
 
 class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
 {
@@ -332,5 +334,11 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(InvalidArgumentException::class);
         new FooPluginManager($arg);
+    }
+
+    public function testV2v3PluginManager()
+    {
+        $pluginManager = new V2v3PluginManager(new ServiceManager());
+        $this->assertInstanceOf(InvokableObject::class, $pluginManager->get('foo'));
     }
 }

--- a/test/TestAsset/V2v3PluginManager.php
+++ b/test/TestAsset/V2v3PluginManager.php
@@ -20,7 +20,9 @@ class V2v3PluginManager extends AbstractPluginManager
     ];
 
     protected $factories = [
-        InvokableObject::class => InvokableFactory::class
+        InvokableObject::class                           => InvokableFactory::class,
+        // Legacy (v2) due to alias resolution
+        'zendtestservicemanagertestassetinvokableobject' => InvokableFactory::class,
     ];
 
     protected $instanceOf = InvokableObject::class;

--- a/test/TestAsset/V2v3PluginManager.php
+++ b/test/TestAsset/V2v3PluginManager.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
+use Zend\ServiceManager\Factory\InvokableFactory;
+
+class V2v3PluginManager extends AbstractPluginManager
+{
+    protected $aliases = [
+        'foo' => InvokableObject::class,
+    ];
+
+    protected $factories = [
+        InvokableObject::class => InvokableFactory::class
+    ];
+
+    protected $instanceOf = InvokableObject::class;
+
+
+    public function validate($plugin)
+    {
+        if ($plugin instanceof $this->instanceOf) {
+            return;
+        }
+
+        throw new InvalidServiceException(sprintf(
+            "'%s' is not an instance of '%s'",
+            get_class($plugin),
+            $this->instanceOf
+        ));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validatePlugin($plugin)
+    {
+        $this->validate($plugin);
+    }
+}


### PR DESCRIPTION
I'm sure I'm doing something really, really dumb, but I'm trying to follow the [migration docs](https://github.com/zendframework/zend-servicemanager/blob/develop/doc/book/migration.md#migration-example) and from what I've read this test should pass. Instead I get:

```
1) ZendTest\ServiceManager\AbstractPluginManagerTest::testV2v3PluginManager
Zend\ServiceManager\Exception\ServiceNotFoundException: An alias "ZendTest\ServiceManager\TestAsset\InvokableObject" was requested but no service could be found.

/Users/matt/www/zend-servicemanager/src/ServiceManager.php:551
/Users/matt/www/zend-servicemanager/src/AbstractPluginManager.php:161
/Users/matt/www/zend-servicemanager/test/AbstractPluginManagerTest.php:342
```

From what I can tell ServiceManager v2 is still looking up factories by their canonicalised name, which would work with:

```php
$serviceManager->setAlias('foo', Foo::class);
$serviceManager->setFactory(Foo::class, Bar::class)
```

...but not when defined in the `alias` and `factories` properties.

Please tell me I'm going mad.