### PR TITLE
Added setCreationOptions() to InvokableFactory

### DIFF
--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -318,8 +318,9 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
             $factory = reset($callable);
         }
 
+        // duck-type MutableCreationOptionsInterface for forward compatibility
         if (isset($factory)
-            && ($factory instanceof MutableCreationOptionsInterface)
+            && method_exists($factory, 'setCreationOptions')
             && is_array($this->creationOptions)
             && !empty($this->creationOptions)
         ) {

--- a/src/Factory/InvokableFactory.php
+++ b/src/Factory/InvokableFactory.php
@@ -12,6 +12,7 @@ namespace Zend\ServiceManager\Factory;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\MutableCreationOptionsInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
@@ -26,7 +27,7 @@ use Zend\ServiceManager\ServiceLocatorInterface;
  * service manager, and can also be used in v2 code for forwards compatibility
  * with v3.
  */
-final class InvokableFactory implements FactoryInterface
+final class InvokableFactory implements FactoryInterface, MutableCreationOptionsInterface
 {
     /**
      * Options to pass to the constructor (when used in v2), if any.
@@ -46,19 +47,7 @@ final class InvokableFactory implements FactoryInterface
             return;
         }
 
-        if ($creationOptions instanceof Traversable) {
-            $creationOptions = iterator_to_array($creationOptions);
-        }
-
-        if (! is_array($creationOptions)) {
-            throw new InvalidServiceException(sprintf(
-                '%s cannot use non-array, non-traversable creation options; received %s',
-                __CLASS__,
-                (is_object($creationOptions) ? get_class($creationOptions) : gettype($creationOptions))
-            ));
-        }
-
-        $this->creationOptions = $creationOptions;
+        $this->setCreationOptions($creationOptions);
     }
 
     /**
@@ -114,5 +103,25 @@ final class InvokableFactory implements FactoryInterface
             '%s requires that the requested name is provided on invocation; please update your tests or consuming container',
             __CLASS__
         ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCreationOptions(array $creationOptions)
+    {
+        if ($creationOptions instanceof Traversable) {
+            $creationOptions = iterator_to_array($creationOptions);
+        }
+
+        if (! is_array($creationOptions)) {
+            throw new InvalidServiceException(sprintf(
+                '%s cannot use non-array, non-traversable creation options; received %s',
+                __CLASS__,
+                (is_object($creationOptions) ? get_class($creationOptions) : gettype($creationOptions))
+            ));
+        }
+
+        $this->creationOptions = $creationOptions;
     }
 }

--- a/src/Factory/InvokableFactory.php
+++ b/src/Factory/InvokableFactory.php
@@ -12,7 +12,6 @@ namespace Zend\ServiceManager\Factory;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\MutableCreationOptionsInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
@@ -27,7 +26,7 @@ use Zend\ServiceManager\ServiceLocatorInterface;
  * service manager, and can also be used in v2 code for forwards compatibility
  * with v3.
  */
-final class InvokableFactory implements FactoryInterface, MutableCreationOptionsInterface
+final class InvokableFactory implements FactoryInterface
 {
     /**
      * Options to pass to the constructor (when used in v2), if any.

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -16,8 +16,6 @@ use Zend\ServiceManager\Config;
 use Zend\ServiceManager\Exception\InvalidArgumentException;
 use Zend\ServiceManager\Exception\RuntimeException;
 use Zend\ServiceManager\Factory\InvokableFactory;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\MutableCreationOptionsInterface;
 use Zend\ServiceManager\ServiceManager;
 use ZendTest\ServiceManager\TestAsset\FooPluginManager;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -15,8 +15,12 @@ use ReflectionObject;
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\Exception\InvalidArgumentException;
 use Zend\ServiceManager\Exception\RuntimeException;
+use Zend\ServiceManager\Factory\InvokableFactory;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\MutableCreationOptionsInterface;
 use Zend\ServiceManager\ServiceManager;
 use ZendTest\ServiceManager\TestAsset\FooPluginManager;
+use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\MockSelfReturningDelegatorFactory;
 
 class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
@@ -332,5 +336,20 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(InvalidArgumentException::class);
         new FooPluginManager($arg);
+    }
+
+    public function testInvokableFactoryHasMutableOptions()
+    {
+        $pluginManager = new FooPluginManager($this->serviceManager);
+        $pluginManager->setAlias('foo', InvokableObject::class);
+        $pluginManager->setFactory(InvokableObject::class, InvokableFactory::class);
+
+        $options = ['option' => 'a'];
+        $object = $pluginManager->get('foo', $options);
+        $this->assertEquals($options, $object->getOptions());
+
+        $options = ['option' => 'b'];
+        $object = $pluginManager->get('foo', $options);
+        $this->assertEquals($options, $object->getOptions());
     }
 }

--- a/test/TestAsset/FooPluginManager.php
+++ b/test/TestAsset/FooPluginManager.php
@@ -13,6 +13,8 @@ use Zend\ServiceManager\AbstractPluginManager;
 
 class FooPluginManager extends AbstractPluginManager
 {
+    protected $shareByDefault = false;
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
I've run into a problem where multiple calls to `get('foo', $options)` on a plugin manager are not setting the options on subsequent calls. I'm an using an alias to `InvokableFactory`, as recommended in the v2-v3 [migration docs](https://github.com/zendframework/zend-servicemanager/blob/master/doc/book/migration.md#migration-example).

This PR addresses that for v2 by adding the `MutableCreationOptionsInterface` to `InvokableFactory`. 

Note that this _only_ works when the plugin manager has been marked `$shareByDefault = false`. I am unable to determine if that is expected behaviour.