### PR TITLE
[v3] configure() now resolves aliases defined as properties

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -341,6 +341,9 @@ class ServiceManager implements ServiceLocatorInterface
 
         if (isset($config['aliases'])) {
             $this->aliases = $config['aliases'] + $this->aliases;
+        }
+
+        if (! empty($this->aliases)) {
             $this->resolveAliases($this->aliases);
         }
 

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -22,6 +22,7 @@ use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\ServiceManager\ServiceManager;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\SimplePluginManager;
+use ZendTest\ServiceManager\TestAsset\V2v3PluginManager;
 
 /**
  * @covers \Zend\ServiceManager\AbstractPluginManager
@@ -365,6 +366,12 @@ class AbstractPluginManagerTest extends TestCase
         $abstractFactory->__invoke($serviceManager, 'foo', null)
             ->willReturn(new InvokableObject());
         $pluginManager->addAbstractFactory($abstractFactory->reveal());
+        $this->assertInstanceOf(InvokableObject::class, $pluginManager->get('foo'));
+    }
+
+    public function testAliasPropertyResolves()
+    {
+        $pluginManager = new V2v3PluginManager(new ServiceManager());
         $this->assertInstanceOf(InvokableObject::class, $pluginManager->get('foo'));
     }
 }

--- a/test/TestAsset/V2v3PluginManager.php
+++ b/test/TestAsset/V2v3PluginManager.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
+use Zend\ServiceManager\Factory\InvokableFactory;
+
+class V2v3PluginManager extends AbstractPluginManager
+{
+    protected $aliases = [
+        'foo' => InvokableObject::class,
+    ];
+
+    protected $factories = [
+        InvokableObject::class                           => InvokableFactory::class,
+        // Legacy (v2) due to alias resolution
+        'zendtestservicemanagertestassetinvokableobject' => InvokableFactory::class,
+    ];
+
+    protected $instanceOf = InvokableObject::class;
+
+    protected $shareByDefault = false;
+
+    protected $sharedByDefault = false;
+
+
+    public function validate($plugin)
+    {
+        if ($plugin instanceof $this->instanceOf) {
+            return;
+        }
+
+        throw new InvalidServiceException(sprintf(
+            "'%s' is not an instance of '%s'",
+            get_class($plugin),
+            $this->instanceOf
+        ));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validatePlugin($plugin)
+    {
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}


### PR DESCRIPTION
This supersedes #87 and fixes the problem with aliases defined in the `$aliases` property not being resolved.