### PR TITLE
Allow proxymanager v2 installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
 
 install:
-  - travis_retry composer install --no-interaction --ignore-platform-reqs
+  - travis_retry composer install --no-interaction
 
 script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.6 || ^5.2.10",
         "ocramius/proxy-manager": "^1.0 || ^2.0",
-        "squizlabs/php_codesniffer": "^2.0@dev",
+        "squizlabs/php_codesniffer": "^2.5.1",
         "phpbench/phpbench": "^0.10.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.6",
-        "ocramius/proxy-manager": "~1.0",
+        "ocramius/proxy-manager": "^1.0 || ^2.0",
         "squizlabs/php_codesniffer": "^2.0@dev",
         "phpbench/phpbench": "^0.10.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "container-interop/container-interop": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.6",
+        "phpunit/phpunit": "^4.6 || ^5.2.10",
         "ocramius/proxy-manager": "^1.0 || ^2.0",
         "squizlabs/php_codesniffer": "^2.0@dev",
         "phpbench/phpbench": "^0.10.0"

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -14,7 +14,9 @@ use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
 use ProxyManager\Configuration as ProxyConfiguration;
 use ProxyManager\Factory\LazyLoadingValueHolderFactory;
+use ProxyManager\FileLocator\FileLocator;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
+use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
 use Zend\ServiceManager\Exception\ContainerModificationsNotAllowedException;
 use Zend\ServiceManager\Exception\CyclicAliasException;
 use Zend\ServiceManager\Exception\InvalidArgumentException;
@@ -750,6 +752,10 @@ class ServiceManager implements ServiceLocatorInterface
 
         if (! isset($this->lazyServices['write_proxy_files']) || ! $this->lazyServices['write_proxy_files']) {
             $factoryConfig->setGeneratorStrategy(new EvaluatingGeneratorStrategy());
+        } else {
+            $factoryConfig->setGeneratorStrategy(new FileWriterGeneratorStrategy(
+                new FileLocator($factoryConfig->getProxiesTargetDir())
+            ));
         }
 
         spl_autoload_register($factoryConfig->getProxyAutoloader());


### PR DESCRIPTION
This patch allows installation of ProxyManager v2.*

The changes are not breaking, but ProxyManager v2 has PHP 7 type-hints everywhere, which means that PHPUnit 5.* is required in order to mock them (specifically, PHPUnit 5.2.9+). This patch adds the required changes, as well as the polyfills required to have ProxyManager v2 behave like ProxyManager v1, configuration-wise