### PR TITLE
Improved `setFactory` and `setAlias` performance

### DIFF
--- a/benchmarks/SetNewServicesBench.php
+++ b/benchmarks/SetNewServicesBench.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace ZendBench\ServiceManager;
+
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use Zend\ServiceManager\ServiceManager;
+
+/**
+ * @Revs(1000)
+ * @Iterations(10)
+ * @Warmup(2)
+ */
+class SetNewServicesBench
+{
+    const NUM_SERVICES = 100;
+    
+    /**
+     * @var ServiceManager
+     */
+    private $sm;
+
+    public function __construct()
+    {
+        
+        $config = [
+            'factories' => [
+                'factory1'  => BenchAsset\FactoryFoo::class,
+            ],
+            'invokables' => [
+                'invokable1' => BenchAsset\Foo::class,
+            ],
+            'services' => [
+                'service1' => new \stdClass(),
+            ],
+            'aliases' => [
+                'factoryAlias1'          => 'factory1',
+                'recursiveFactoryAlias1' => 'factoryAlias1',
+                'recursiveFactoryAlias2' => 'recursiveFactoryAlias1',
+            ],
+            'abstract_factories' => [
+                BenchAsset\AbstractFactoryFoo::class
+            ],
+        ];
+        
+        $service = new \stdClass();
+        for ($i = 0; $i <= self::NUM_SERVICES; $i++) {
+            $config['factories']["factory_$i"]    = BenchAsset\FactoryFoo::class;
+            $config['aliases']["alias_$i"]        = "service_$i";
+        }
+        
+        $this->sm = new ServiceManager($config);
+    }
+
+    public function benchSetFactory()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+
+        $sm->setFactory('factory2', BenchAsset\FactoryFoo::class);
+    }
+
+    public function benchSetAlias()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+
+        $sm->setAlias('factoryAlias2', 'factory1');
+    }
+
+    public function benchSetAliasOverrided()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+
+        $sm->setAlias('recursiveFactoryAlias1', 'factory1');
+    }
+}

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -322,6 +322,7 @@ class ServiceManager implements ServiceLocatorInterface
                     ? array_merge($config['aliases'], $aliases)
                     : $aliases;
             }
+
             $config['factories'] = (isset($config['factories']))
                 ? array_merge($config['factories'], $factories)
                 : $factories;

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -322,7 +322,6 @@ class ServiceManager implements ServiceLocatorInterface
                     ? array_merge($config['aliases'], $aliases)
                     : $aliases;
             }
-
             $config['factories'] = (isset($config['factories']))
                 ? array_merge($config['factories'], $factories)
                 : $factories;
@@ -341,10 +340,18 @@ class ServiceManager implements ServiceLocatorInterface
         }
 
         if (isset($config['aliases'])) {
-            $this->aliases = $config['aliases'] + $this->aliases;
-        }
-
-        if (! empty($this->aliases)) {
+            if ($this->configured) {
+                $intersect = $this->mergeIntoArray($this->aliases, $config['aliases']);
+                if ($intersect) {
+                    $this->resolveAliases($this->aliases);
+                } else {
+                    $this->resolveAliases($config['aliases'], true);
+                }
+            } else {
+                $this->aliases = $config['aliases'] + $this->aliases;
+                $this->resolveAliases($this->aliases);
+            }
+        } elseif (! $this->configured && ! empty($this->aliases)) {
             $this->resolveAliases($this->aliases);
         }
 
@@ -372,6 +379,35 @@ class ServiceManager implements ServiceLocatorInterface
         $this->configured = true;
 
         return $this;
+    }
+
+    /**
+     * Merge source into destination.
+     * This method has good performance:
+     *  - at empty destination
+     *  - at adding few elements into array
+     *  - at checking arrays keys intersection
+     *
+     * Provide only present intersect
+     *
+     * @param array $destination
+     * @param array $source
+     * @return boolean
+     */
+    private function mergeIntoArray(array &$destination, array &$source)
+    {
+        if (empty($destination)) {
+            $destination = $source;
+            return false;
+        }
+        $intersect = false;
+        foreach ($source as $name => $target) {
+            if (isset($destination[$name])) {
+                $intersect = true;
+            }
+            $destination[$name] = $target;
+        }
+        return $intersect;
     }
 
     /**
@@ -568,9 +604,12 @@ class ServiceManager implements ServiceLocatorInterface
     }
 
     /**
-     * Resolve all aliases to their canonical service names.
+     * Resolve aliases to their canonical service names.
+     *
+     * @param array $aliases
+     * @param boolean $onlyNewAliases
      */
-    private function resolveAliases(array $aliases)
+    private function resolveAliases(array $aliases, $onlyNewAliases = false)
     {
         foreach ($aliases as $alias => $service) {
             $visited = [];
@@ -586,6 +625,16 @@ class ServiceManager implements ServiceLocatorInterface
             }
 
             $this->resolvedAliases[$alias] = $name;
+        }
+
+        // Check and replace new aliases as targets in exists aliases.
+
+        if ($onlyNewAliases) {
+            foreach ($this->resolvedAliases as $name => $target) {
+                if (isset($aliases[$target])) {
+                    $this->resolvedAliases[$name] = $this->resolvedAliases[$target];
+                }
+            }
         }
     }
 

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -236,4 +236,29 @@ class ServiceManagerTest extends TestCase
 
         $this->assertSame($service, $alias);
     }
+
+    /**
+     * @depends testAliasToAnExplicitServiceShouldWork
+     */
+    public function testSetAliasShouldWorkWithRecursiveAlias()
+    {
+        $config = [
+            'aliases' => [
+                'Alias' => 'TailInvokable',
+            ],
+            'services' => [
+                InvokableObject::class => new InvokableObject(),
+            ],
+        ];
+        $serviceManager = new ServiceManager($config);
+        $serviceManager->setAlias('HeadAlias', 'Alias');
+        $serviceManager->setAlias('TailInvokable', InvokableObject::class);
+
+        $service   = $serviceManager->get(InvokableObject::class);
+        $alias     = $serviceManager->get('Alias');
+        $headAlias = $serviceManager->get('HeadAlias');
+
+        $this->assertSame($service, $alias);
+        $this->assertSame($service, $headAlias);
+    }
 }


### PR DESCRIPTION
All discussion is in #112 

Provided PR give advantages on methods:
 - ```setFactory``` is now 9x faster
 - ```setAlias``` (for not intersecting case) is 3x faster 
 - all set methods that use ```configure```

