### PR TITLE
Add setAliases and setFactories methods branch 2.7

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -303,6 +303,22 @@ class ServiceManager implements ServiceLocatorInterface, ContainerInterface
     }
 
     /**
+     * Set factories
+     *
+     * @param  array $nameFactoryPairs
+     * @return ServiceManager
+     * @throws Exception\InvalidArgumentException
+     * @throws Exception\InvalidServiceNameException
+     */
+    public function setFactories($nameFactoryPairs)
+    {
+        foreach ($nameFactoryPairs as $name => $factory) {
+            $this->setFactory($name, $factory);
+        }
+        return $this;
+    }
+
+    /**
      * Add abstract factory
      *
      * @param  AbstractFactoryInterface|string $factory

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -848,6 +848,20 @@ class ServiceManager implements ServiceLocatorInterface, ContainerInterface
     }
 
     /**
+     * @param  array $aliasNamePairs
+     * @return ServiceManager
+     * @throws Exception\ServiceNotFoundException
+     * @throws Exception\InvalidServiceNameException
+     */
+    public function setAliases($aliasNamePairs)
+    {
+        foreach ($aliasNamePairs as $alias => $nameOrAlias) {
+            $this->setAlias($alias, $nameOrAlias);
+        }
+        return $this;
+    }
+
+    /**
      * Determine if we have an alias
      *
      * @param  string $alias

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -95,6 +95,19 @@ class ServiceManagerTest extends TestCase
     }
 
     /**
+     * @covers Zend\ServiceManager\ServiceManager::setFactories
+     * @depends testSetFactory
+     */
+    public function testSetFactories()
+    {
+        $ret = $this->serviceManager->setFactories([
+            'foo' => 'bar',
+            'baz' => 'bar',
+        ]);
+        $this->assertSame($this->serviceManager, $ret);
+    }
+
+    /**
      * @covers Zend\ServiceManager\ServiceManager::setFactory
      */
     public function testSetFactoryThrowsExceptionOnDuplicate()
@@ -429,6 +442,20 @@ class ServiceManagerTest extends TestCase
     {
         $this->serviceManager->setInvokableClass('foo', 'bar');
         $ret = $this->serviceManager->setAlias('bar', 'foo');
+        $this->assertSame($this->serviceManager, $ret);
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::setAliases
+     * @depends testSetAlias
+     */
+    public function testSetAliases()
+    {
+        $this->serviceManager->setInvokableClass('foo', 'bar');
+        $ret = $this->serviceManager->setAliases([
+            'bar' => 'foo',
+            'baz' => 'foo',
+        ]);
         $this->assertSame($this->serviceManager, $ret);
     }
 


### PR DESCRIPTION
We should add methods to  branch 2.7 in order to change other components that to use them before we migrate to SM3.

More information could be found here #112

All components listed in symmetric PR #114