### PR TITLE
Changed the way ContainerInterface is implemented

### DIFF
--- a/src/ServiceLocatorInterface.php
+++ b/src/ServiceLocatorInterface.php
@@ -9,10 +9,12 @@
 
 namespace Zend\ServiceManager;
 
+use Interop\Container\ContainerInterface;
+
 /**
  * Service locator interface
  */
-interface ServiceLocatorInterface
+interface ServiceLocatorInterface extends ContainerInterface
 {
     /**
      * Retrieve a registered instance

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -9,9 +9,7 @@
 
 namespace Zend\ServiceManager;
 
-use Interop\Container\ContainerInterface;
-
-class ServiceManager implements ServiceLocatorInterface, ContainerInterface
+class ServiceManager implements ServiceLocatorInterface
 {
     /**@#+
      * Constants


### PR DESCRIPTION
Forward compatibility change, `ServiceLocatorInterface` now extends `ContainerInterface`, and therefore `ServiceManager` no longer implements the `ContainerInterface`