### PR TITLE
phpunit removed getMock

### DIFF
--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -39,7 +39,8 @@ class AbstractPluginManagerTest extends TestCase
 
     public function testInjectCreationContextInFactories()
     {
-        $invokableFactory = $this->getMock(FactoryInterface::class);
+        $invokableFactory = $this->getMockBuilder(FactoryInterface::class)
+            ->getMock();
 
         $config = [
             'factories' => [
@@ -47,7 +48,8 @@ class AbstractPluginManagerTest extends TestCase
             ],
         ];
 
-        $container     = $this->getMock(ContainerInterface::class);
+        $container     = $this->getMockBuilder(ContainerInterface::class)
+            ->getMock();
         $pluginManager = new SimplePluginManager($container, $config);
 
         $invokableFactory->expects($this->once())
@@ -69,7 +71,8 @@ class AbstractPluginManagerTest extends TestCase
             ],
         ];
 
-        $container     = $this->getMock(ContainerInterface::class);
+        $container     = $this->getMockBuilder(ContainerInterface::class)
+            ->getMock();
         $pluginManager = new SimplePluginManager($container, $config);
 
         // Assert no exception is triggered because the plugin manager validate ObjectWithOptions
@@ -88,7 +91,8 @@ class AbstractPluginManagerTest extends TestCase
             ],
         ];
 
-        $container     = $this->getMock(ContainerInterface::class);
+        $container     = $this->getMockBuilder(ContainerInterface::class)
+            ->getMock();
         $pluginManager = new SimplePluginManager($container, $config);
 
         $first  = $pluginManager->get(InvokableObject::class);
@@ -119,7 +123,8 @@ class AbstractPluginManagerTest extends TestCase
         ];
         $options = ['foo' => 'bar'];
 
-        $container     = $this->getMock(ContainerInterface::class);
+        $container     = $this->getMockBuilder(ContainerInterface::class)
+            ->getMock();
         $pluginManager = new SimplePluginManager($container, $config);
 
         $first  = $pluginManager->get(InvokableObject::class, $options);

--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -192,7 +192,8 @@ trait CommonServiceLocatorBehaviorsTrait
 
     public function testInitializersAreRunAfterCreation()
     {
-        $initializer = $this->getMock(InitializerInterface::class);
+        $initializer = $this->getMockBuilder(InitializerInterface::class)
+            ->getMock();
 
         $serviceManager = $this->createContainer([
             'factories' => [
@@ -251,8 +252,10 @@ trait CommonServiceLocatorBehaviorsTrait
 
     public function testConfigureCanOverridePreviousSettings()
     {
-        $firstFactory  = $this->getMock(FactoryInterface::class);
-        $secondFactory = $this->getMock(FactoryInterface::class);
+        $firstFactory  = $this->getMockBuilder(FactoryInterface::class)
+            ->getMock();
+        $secondFactory = $this->getMockBuilder(FactoryInterface::class)
+            ->getMock();
 
         $serviceManager = $this->createContainer([
             'factories' => [

--- a/test/Factory/InvokableFactoryTest.php
+++ b/test/Factory/InvokableFactoryTest.php
@@ -21,7 +21,8 @@ class InvokableFactoryTest extends TestCase
 {
     public function testCanCreateObject()
     {
-        $container = $this->getMock(ContainerInterface::class);
+        $container = $this->getMockBuilder(ContainerInterface::class)
+            ->getMock();
         $factory   = new InvokableFactory();
 
         $object = $factory($container, InvokableObject::class, ['foo' => 'bar']);

--- a/test/Proxy/LazyServiceFactoryTest.php
+++ b/test/Proxy/LazyServiceFactoryTest.php
@@ -39,7 +39,8 @@ class LazyServiceFactoryTest extends TestCase
      */
     protected function setUp()
     {
-        $this->proxyFactory = $this->getMock(LazyLoadingValueHolderFactory::class);
+        $this->proxyFactory = $this->getMockBuilder(LazyLoadingValueHolderFactory::class)
+            ->getMock();
         $servicesMap = [
             'fooService' => 'FooClass',
         ];
@@ -54,10 +55,12 @@ class LazyServiceFactoryTest extends TestCase
 
     public function testThrowExceptionWhenServiceNotExists()
     {
-        $callback = $this->getMock('stdClass', ['callback']);
+        $callback = $this->getMockBuilder('stdClass')
+            ->setMethods(['callback'])
+            ->getMock();
         $callback->expects($this->never())
-            ->method('callback')
-        ;
+            ->method('callback');
+
         $container = $this->createContainerMock();
 
         $this->proxyFactory->expects($this->never())
@@ -73,13 +76,16 @@ class LazyServiceFactoryTest extends TestCase
 
     public function testCreates()
     {
-        $callback = $this->getMock('stdClass', ['callback']);
+        $callback = $this->getMockBuilder('stdClass')
+            ->setMethods(['callback'])
+            ->getMock();
         $callback->expects($this->once())
             ->method('callback')
             ->willReturn('fooValue')
         ;
         $container = $this->createContainerMock();
-        $expectedService = $this->getMock(VirtualProxyInterface::class);
+        $expectedService = $this->getMockBuilder(VirtualProxyInterface::class)
+            ->getMock();
 
         $this->proxyFactory->expects($this->once())
             ->method('createProxy')
@@ -88,7 +94,10 @@ class LazyServiceFactoryTest extends TestCase
                     $this->assertEquals('FooClass', $className, 'class name not match');
 
                     $wrappedInstance = null;
-                    $result = $initializer($wrappedInstance, $this->getMock(LazyLoadingInterface::class));
+                    $result = $initializer(
+                        $wrappedInstance,
+                        $this->getMockBuilder(LazyLoadingInterface::class)->getMock()
+                    );
 
                     $this->assertEquals('fooValue', $wrappedInstance, 'expected callback return value');
                     $this->assertTrue($result, 'initializer should return true');
@@ -109,7 +118,8 @@ class LazyServiceFactoryTest extends TestCase
     private function createContainerMock()
     {
         /** @var ContainerInterface|MockObject $container */
-        $container = $this->getMock(ContainerInterface::class);
+        $container = $this->getMockBuilder(ContainerInterface::class)
+            ->getMock();
 
         return $container;
     }

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -46,7 +46,8 @@ class ServiceManagerTest extends TestCase
 
     public function testConfigurationTakesPrecedenceWhenMerged()
     {
-        $factory = $this->getMock(FactoryInterface::class);
+        $factory = $this->getMockBuilder(FactoryInterface::class)
+            ->getMock();
 
         $factory->expects($this->once())->method('__invoke');
 


### PR DESCRIPTION
unit tests update, phpunit set getMock on deprecated

https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-5.4.0#changes