### PR TITLE
InitializerInterface already in use

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -24,7 +24,7 @@ use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\Factory\AbstractFactoryInterface;
 use Zend\ServiceManager\Factory\DelegatorFactoryInterface;
-use Zend\ServiceManager\Initializer\InitializerInterface;
+use Zend\ServiceManager\Initializer\InitializerInterface as InitializerInitializerInterface;
 
 /**
  * Service Manager.
@@ -82,7 +82,7 @@ class ServiceManager implements ServiceLocatorInterface
     protected $factories = [];
 
     /**
-     * @var InitializerInterface[]
+     * @var InitializerInitializerInterface[]
      */
     protected $initializers = [];
 
@@ -475,7 +475,7 @@ class ServiceManager implements ServiceLocatorInterface
     /**
      * Add an initializer.
      *
-     * @param string|callable|InitializerInterface $initializer
+     * @param string|callable|InitializerInitializerInterface $initializer
      */
     public function addInitializer($initializer)
     {
@@ -553,7 +553,7 @@ class ServiceManager implements ServiceLocatorInterface
     /**
      * Instantiate initializers for to avoid checks during service construction.
      *
-     * @param string[]|callable[]|InitializerInterface[] $initializers
+     * @param string[]|callable[]|InitializerInitializerInterface[] $initializers
      *
      * @return void
      */
@@ -578,7 +578,7 @@ class ServiceManager implements ServiceLocatorInterface
                         'which does not exist; please provide a valid function name or class ' .
                         'name resolving to an implementation of %s',
                         $initializer,
-                        InitializerInterface::class
+                        InitializerInitializerInterface::class
                     )
                 );
             }
@@ -589,7 +589,7 @@ class ServiceManager implements ServiceLocatorInterface
                     'An invalid initializer was registered. Expected a callable, or an instance of ' .
                     '(or string class name resolving to) "%s", ' .
                     'but "%s" was received',
-                    InitializerInterface::class,
+                    InitializerInitializerInterface::class,
                     (is_object($initializer) ? get_class($initializer) : gettype($initializer))
                 )
             );

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -24,7 +24,7 @@ use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\Factory\AbstractFactoryInterface;
 use Zend\ServiceManager\Factory\DelegatorFactoryInterface;
-use Zend\ServiceManager\Initializer\InitializerInterface as InitializerInitializerInterface;
+use Zend\ServiceManager\Initializer;
 
 /**
  * Service Manager.
@@ -82,7 +82,7 @@ class ServiceManager implements ServiceLocatorInterface
     protected $factories = [];
 
     /**
-     * @var InitializerInitializerInterface[]
+     * @var Initializer\InitializerInterface[]
      */
     protected $initializers = [];
 
@@ -475,7 +475,7 @@ class ServiceManager implements ServiceLocatorInterface
     /**
      * Add an initializer.
      *
-     * @param string|callable|InitializerInitializerInterface $initializer
+     * @param string|callable|Initializer\InitializerInterface $initializer
      */
     public function addInitializer($initializer)
     {
@@ -553,7 +553,7 @@ class ServiceManager implements ServiceLocatorInterface
     /**
      * Instantiate initializers for to avoid checks during service construction.
      *
-     * @param string[]|callable[]|InitializerInitializerInterface[] $initializers
+     * @param string[]|callable[]|Initializer\InitializerInterface[] $initializers
      *
      * @return void
      */
@@ -578,7 +578,7 @@ class ServiceManager implements ServiceLocatorInterface
                         'which does not exist; please provide a valid function name or class ' .
                         'name resolving to an implementation of %s',
                         $initializer,
-                        InitializerInitializerInterface::class
+                        Initializer\InitializerInterface::class
                     )
                 );
             }
@@ -589,7 +589,7 @@ class ServiceManager implements ServiceLocatorInterface
                     'An invalid initializer was registered. Expected a callable, or an instance of ' .
                     '(or string class name resolving to) "%s", ' .
                     'but "%s" was received',
-                    InitializerInitializerInterface::class,
+                    Initializer\InitializerInterface::class,
                     (is_object($initializer) ? get_class($initializer) : gettype($initializer))
                 )
             );


### PR DESCRIPTION
i found on my fail pull request:

https://travis-ci.org/bjyoungblood/BjyAuthorize/jobs/144009025

Cannot use Zend\ServiceManager\Initializer\InitializerInterface as InitializerInterface because the name is already in use in `ServiceManager.php` on line 27

im not realy sure about the alias name to resolve problem, so im open for other solutions.