### PR TITLE
Fix: Remove unused imports

### DIFF
--- a/src/ServiceLocatorInterface.php
+++ b/src/ServiceLocatorInterface.php
@@ -11,7 +11,6 @@ namespace Zend\ServiceManager;
 
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
-use Zend\ServiceManager\Exception;
 
 /**
  * Interface for service locator

--- a/test/Exception/CyclicAliasExceptionTest.php
+++ b/test/Exception/CyclicAliasExceptionTest.php
@@ -10,19 +10,7 @@
 namespace ZendTest\ServiceManager\Exception;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use ProxyManager\Autoloader\AutoloaderInterface;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use RecursiveRegexIterator;
-use RegexIterator;
-use stdClass;
 use Zend\ServiceManager\Exception\CyclicAliasException;
-use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\Factory\InvokableFactory;
-use Zend\ServiceManager\Proxy\LazyServiceFactory;
-use Zend\ServiceManager\ServiceManager;
-use ZendTest\ServiceManager\TestAsset\InvokableObject;
 
 /**
  * @covers \Zend\ServiceManager\Exception\CyclicAliasException

--- a/test/TestAsset/PreDelegator.php
+++ b/test/TestAsset/PreDelegator.php
@@ -10,7 +10,6 @@
 namespace ZendTest\ServiceManager\TestAsset;
 
 use Interop\Container\ContainerInterface;
-use stdClass;
 use Zend\ServiceManager\Factory\DelegatorFactoryInterface;
 
 class PreDelegator implements DelegatorFactoryInterface


### PR DESCRIPTION
This PR

* [x] removes unused imports

💁 Ran

```
$ composer global require friendsofphp/php-cs-fixer:2.0.0-alpha
$ php-cs-fixer fix --using-cache=no --rules=no_unused_imports .
```