### PR TITLE
[docs] Don't return $instance in initializer callable doc

### DIFF
--- a/doc/book/migration.md
+++ b/doc/book/migration.md
@@ -892,10 +892,9 @@ class FooInitializer implements InitializerInterface
 >          $instance = $first;
 >      }
 >      if (! $instance implements FooAwareInterface) {
->          return $instance;
+>          return;
 >      }
 >      $container->setFoo($services->get(FooInterface::class);
->      return $instance;
 > });
 > ```
 >


### PR DESCRIPTION
`Zend\ServiceManager\Initializer\InitializerInterface::__invoke()`'s docblock says that it does not return the instance, so the migration documentation should not either.

FWiW, the V2 example probably should't return `$instance` either. However, the V2 interface says that it returns `mixed`, even though v2's `ServiceManager` doesn't do anything with it in `doCreate()`. Wasn't sure what to do with the V2 one, so left it alone.