### PR TITLE
Updated to mark PHP 5.6 as minimum supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,14 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
-      env:
-        - EXECUTE_CS_CHECK=true
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
         - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
         - PATH="$HOME/.local/bin:$PATH"
     - php: 7
+      env:
+        - EXECUTE_CS_CHECK=true
     - php: hhvm 
   allow_failures:
     - php: hhvm

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "container-interop/container-interop": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Per our other repositories, and in preparation for the next minor version.