### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - secure: "KoLcNj22t668IhAhm5ej6DNf23waoGrZpQ1kmuq5ptTqsXjFjy/cjOJCvWOeRX62Tl2kjc7co9UeK0f91osZ2Wq7HLb+1bIXX5SrB6SfyPUajCQtCtu0xGgEKZfuQwzLWSYoR3tsaD6vqgMjKwwst10d+AyICjdLNu9dHtdu9HpozZtK3kM9+0FwMOiRqFEND2GY05oVYXOrzgu1xNmE1YEGpjKzqqBNpqFOP4W+OnTMRTQcyrlbFzOFvAip7X3GGw9iUSnSzZTnIOWJgMdah8/eFqhrPO8O73faW+/v3ZTxdwupOEZyg7s3TD6+W9rjmN+TgOZEP484PcSlUc6sXA4QM4iL8xthG3bWk8+CDrsnuQmunrXz7T5xUEHs/7B8NuGJ8yT89fMCYGySERKIfCx17+N9kP/848A/+39LE1NIlTxnaPISfm9WMNG67xsEKyJluC/YataPGl0zZ6/7Q7w1oDYvjhsqooUsxKRD2/psd1zrVDJurDa7Ayv/E21u2dIDtbp6w9Zl+he+kwRItMNhtCdzyShqtuY0V/JRmn2lZY2PsfbICRXXAbQnDveNFYz5tE2K40Qm4RWrdZ4cnaLiNJeukdYKVJCFHtZr9rdx1uVeK78Pf5o3rt4S8S1aat35eMZQunc6s4gmeXU5+wIxwXiyOtkdlL3LztSox9s="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.5
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.