### PR TITLE
Removing class_exists($canonicalName) call from InvokableFactory v2

### DIFF
--- a/src/Factory/InvokableFactory.php
+++ b/src/Factory/InvokableFactory.php
@@ -65,22 +65,8 @@ final class InvokableFactory implements FactoryInterface
     /**
      * Create an instance of the named service.
      *
-     * First, it checks if `$canonicalName` resolves to a class, and, if so, uses
-     * that value to proxy to `__invoke()`.
-     *
-     * Next, if `$requestedName` is non-empty and resolves to a class, this
-     * method uses that value to proxy to `__invoke()`.
-     *
-     * Finally, if the above each fail, it raises an exception.
-     *
-     * The approach above is performed as version 2 has two distinct behaviors
-     * under which factories are invoked:
-     *
-     * - If an alias was used, $canonicalName is the resolved name, and
-     *   $requestedName is the service name requested, in which case $canonicalName
-     *   is likely the qualified class name;
-     * - Otherwise, $canonicalName is the normalized name, and $requestedName
-     *   is the original service name requested (typically the qualified class name).
+     * If `$requestedName` resolves to a class, this method uses that value
+     * to proxy to `__invoke()`; otherwise, raises an exception.
      *
      * @param ServiceLocatorInterface $serviceLocator
      * @param null|string $canonicalName
@@ -90,11 +76,7 @@ final class InvokableFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator, $canonicalName = null, $requestedName = null)
     {
-        if (class_exists($canonicalName)) {
-            return $this($serviceLocator, $canonicalName, $this->creationOptions);
-        }
-
-        if (is_string($requestedName) && class_exists($requestedName)) {
+        if (class_exists($requestedName)) {
             return $this($serviceLocator, $requestedName, $this->creationOptions);
         }
 

--- a/src/Factory/InvokableFactory.php
+++ b/src/Factory/InvokableFactory.php
@@ -65,8 +65,13 @@ final class InvokableFactory implements FactoryInterface
     /**
      * Create an instance of the named service.
      *
-     * If `$requestedName` resolves to a class, this method uses that value
-     * to proxy to `__invoke()`; otherwise, raises an exception.
+     * First, it checks if `$requestedName` is non-empty and resolves to a class, and, if so, uses
+     * that value to proxy to `__invoke()`.
+     *
+     * Next, if `$canonicalName` resolves to a class, this method uses that value
+     * to proxy to `__invoke()`.
+     *
+     * Finally, if the above each fail, it raises an exception.
      *
      * @param ServiceLocatorInterface $serviceLocator
      * @param null|string $canonicalName
@@ -76,8 +81,12 @@ final class InvokableFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator, $canonicalName = null, $requestedName = null)
     {
-        if (class_exists($requestedName)) {
+        if (is_string($requestedName) && class_exists($requestedName)) {
             return $this($serviceLocator, $requestedName, $this->creationOptions);
+        }
+
+        if (class_exists($canonicalName)) {
+            return $this($serviceLocator, $canonicalName, $this->creationOptions);
         }
 
         throw new InvalidServiceException(sprintf(

--- a/test/Factory/InvokableFactoryTest.php
+++ b/test/Factory/InvokableFactoryTest.php
@@ -42,14 +42,13 @@ class InvokableFactoryTest extends TestCase
         $this->assertInstanceOf(InvokableObject::class, $object);
     }
 
-    public function testCanCreateObjectViaCreateServiceWhenCanonicalNameIsQualified()
+    public function testRaisesExceptionIfCanonicalNameIsQualifiedAndRequestedNameIsNotQualified()
     {
         $container = new ServiceManager();
         $factory   = new InvokableFactory();
 
-        $object = $factory->createService($container, InvokableObject::class, 'invokableobject');
-
-        $this->assertInstanceOf(InvokableObject::class, $object);
+        $this->setExpectedException(InvalidServiceException::class);
+        $factory->createService($container, InvokableObject::class, 'invokableobject');
     }
 
     public function testRaisesExceptionIfNeitherCanonicalNorRequestedNameAreQualified()
@@ -66,7 +65,7 @@ class InvokableFactoryTest extends TestCase
         $container = new ServiceManager();
         $factory   = new InvokableFactory(['foo' => 'bar']);
 
-        $object = $factory->createService($container, InvokableObject::class);
+        $object = $factory->createService($container, 'invokableobject', InvokableObject::class);
 
         $this->assertInstanceOf(InvokableObject::class, $object);
         $this->assertEquals(['foo' => 'bar'], $object->options);

--- a/test/Factory/InvokableFactoryTest.php
+++ b/test/Factory/InvokableFactoryTest.php
@@ -42,13 +42,14 @@ class InvokableFactoryTest extends TestCase
         $this->assertInstanceOf(InvokableObject::class, $object);
     }
 
-    public function testRaisesExceptionIfCanonicalNameIsQualifiedAndRequestedNameIsNotQualified()
+    public function testCanCreateObjectViaCreateServiceWhenCanonicalNameIsQualified()
     {
         $container = new ServiceManager();
         $factory   = new InvokableFactory();
 
-        $this->setExpectedException(InvalidServiceException::class);
-        $factory->createService($container, InvokableObject::class, 'invokableobject');
+        $object = $factory->createService($container, InvokableObject::class, 'invokableobject');
+
+        $this->assertInstanceOf(InvokableObject::class, $object);
     }
 
     public function testRaisesExceptionIfNeitherCanonicalNorRequestedNameAreQualified()
@@ -65,7 +66,7 @@ class InvokableFactoryTest extends TestCase
         $container = new ServiceManager();
         $factory   = new InvokableFactory(['foo' => 'bar']);
 
-        $object = $factory->createService($container, 'invokableobject', InvokableObject::class);
+        $object = $factory->createService($container, InvokableObject::class);
 
         $this->assertInstanceOf(InvokableObject::class, $object);
         $this->assertEquals(['foo' => 'bar'], $object->options);


### PR DESCRIPTION
This pull request removes the `class_exists()` call with `$canonicalName` argument from v2 `Zend\ServiceManager\Factory\InvokableFactory::createService()` method (#61).

Since #69 changed the service alias resoultion, InvokableFactory recieves FQCN via $requestedName parameter.
`class_exists($canonicalName)` produces an extra autoloader call which is either redundant (as $canonicalName now contains a canonicalized service name if actual name or alias is given), or may lead to an unexpected behaviour, as `$canonicalName` may be an actual name of another class. In that case it can be pulled by autoloader, making the factory produce an object of that class.

A positive test case for creating an object of $canonicalName class is converted to a negative one, expecting a `Zend\ServiceManager\Exception\InvalidServiceException` expection to be thrown.
