### PR TITLE
Fix #159 by resetting creation options to NULL

### DIFF
--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -326,7 +326,7 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
         ) {
             $factory->setCreationOptions($this->creationOptions);
         } elseif ($factory instanceof Factory\InvokableFactory) {
-            $factory->setCreationOptions([]);
+            $factory->setCreationOptions(null);
         }
 
         return parent::createServiceViaCallback($callable, $cName, $rName);

--- a/src/Factory/InvokableFactory.php
+++ b/src/Factory/InvokableFactory.php
@@ -107,7 +107,7 @@ final class InvokableFactory implements FactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function setCreationOptions(array $creationOptions)
+    public function setCreationOptions(array $creationOptions = null)
     {
         $this->creationOptions = $creationOptions;
     }

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -151,6 +151,18 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         $plugin2 = $pluginManager->get(Baz::class);
 
         $this->assertNotEquals($plugin1, $plugin2);
+    }
+
+    public function testInvokableFactoryNoOptionsResetsCreationOptions()
+    {
+        /** @var $pluginManager AbstractPluginManager */
+        $pluginManager = $this->getMockForAbstractClass('Zend\ServiceManager\AbstractPluginManager');
+        $pluginManager->setFactory(Baz::class, InvokableFactory::class);
+        $pluginManager->setShared(Baz::class, false);
+        $creationOptions = ['key1' => 'value1'];
+        $plugin1 = $pluginManager->get(Baz::class, $creationOptions);
+        $plugin2 = $pluginManager->get(Baz::class);
+
         $this->assertSame($creationOptions, $plugin1->getOptions());
         $this->assertNull($plugin2->getOptions());
     }

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -151,6 +151,8 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         $plugin2 = $pluginManager->get(Baz::class);
 
         $this->assertNotEquals($plugin1, $plugin2);
+        $this->assertSame($creationOptions, $plugin1->getOptions());
+        $this->assertNull($plugin2->getOptions());
     }
 
     public function testValidatePluginIsCalledWithDelegatorFactoryIfItsAService()

--- a/test/TestAsset/Baz.php
+++ b/test/TestAsset/Baz.php
@@ -17,4 +17,9 @@ class Baz
     {
         $this->options = $options;
     }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
 }


### PR DESCRIPTION
I'm afraid you might consider this a BC break because of changing the signature of `setCreationOptions()`

See #159 
