### PR TITLE
Fix storing shared status of peering service manager services

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -1037,7 +1037,8 @@ class ServiceManager implements ServiceLocatorInterface
             $peeringServiceManager->serviceManagerCaller = $this;
 
             if ($peeringServiceManager->has($name)) {
-                $this->shared[$name] = $peeringServiceManager->isShared($name);
+                $cname = $this->canonicalizeName($name);
+                $this->shared[$cname] = $peeringServiceManager->isShared($name);
                 $instance = $peeringServiceManager->get($name);
                 $peeringServiceManager->serviceManagerCaller = null;
                 return $instance;

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -463,7 +463,7 @@ class ServiceManager implements ServiceLocatorInterface
      * @return bool|null
      * @throws Exception\ServiceNotFoundException
      */
-    public function getShared($name, $usePeeringServiceManagers = true)
+    private function getShared($name, $usePeeringServiceManagers = true)
     {
         $cName = $this->canonicalizeName($name);
 

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -467,14 +467,6 @@ class ServiceManager implements ServiceLocatorInterface
     {
         $cName = $this->canonicalizeName($name);
 
-        if (!$this->has($name)) {
-            throw new Exception\ServiceNotFoundException(sprintf(
-                '%s: A service by the name "%s" was not found',
-                get_class($this) . '::' . __FUNCTION__,
-                $name
-            ));
-        }
-
         if (!isset($this->shared[$cName]) && $usePeeringServiceManagers) {
             $caller = $this->serviceManagerCaller;
             foreach ($this->peeringServiceManagers as $peeringServiceManager) {

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -460,7 +460,7 @@ class ServiceManager implements ServiceLocatorInterface
      *
      * @param  string $name
      * @param  bool   $usePeeringServiceManagers
-     * @return bool
+     * @return bool|null
      * @throws Exception\ServiceNotFoundException
      */
     public function getShared($name, $usePeeringServiceManagers = true)

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -460,7 +460,7 @@ class ServiceManager implements ServiceLocatorInterface
      *
      * @param  string $name
      * @param  bool   $usePeeringServiceManagers
-     * @return bool|null
+     * @return bool
      * @throws Exception\ServiceNotFoundException
      */
     public function getShared($name, $usePeeringServiceManagers = true)
@@ -499,7 +499,7 @@ class ServiceManager implements ServiceLocatorInterface
             return $this->shared[$cName];
         }
 
-        return null;
+        return;
     }
 
     /**


### PR DESCRIPTION
When a service is retrieved from the peering service manager the shared entry is stored with a non canonicalized name. This can lead to unwanted behaviour of services not treated as non-shared later.

This fix is only for these who need to use the peering functionality in the 2.x version.