### PR TITLE
Generate deps ignoring unresolved dependencies

### DIFF
--- a/src/Tool/ConfigDumper.php
+++ b/src/Tool/ConfigDumper.php
@@ -7,6 +7,7 @@
 
 namespace Zend\ServiceManager\Tool;
 
+use Interop\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionParameter;
 use Traversable;
@@ -26,12 +27,34 @@ return %s;
 EOC;
 
     /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param ContainerInterface $container
+     */
+    public function setContainer(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
      * @param array $config
      * @param string $className
+     * @param bool $ignoreUnresolved
      * @return array
      * @throws InvalidArgumentException for invalid $className
      */
-    public function createDependencyConfig(array $config, $className)
+    public function createDependencyConfig(array $config, $className, $ignoreUnresolved = false)
     {
         $this->validateClassName($className);
 
@@ -60,11 +83,19 @@ EOC;
             return $this->createInvokable($config, $className);
         }
 
-        $config[ConfigAbstractFactory::class][$className] = [];
+        $classConfig = [];
 
         foreach ($constructorArguments as $constructorArgument) {
             $argumentType = $constructorArgument->getClass();
             if (is_null($argumentType)) {
+                if ($ignoreUnresolved) {
+                    // don't throw an exception, just return the previous config
+                    return $config;
+                }
+                // don't throw an exception if the class is an already defined service
+                if ($this->container && $this->container->has($className)) {
+                    return $config;
+                }
                 throw new InvalidArgumentException(sprintf(
                     'Cannot create config for constructor argument "%s", '
                     . 'it has no type hint, or non-class/interface type hint',
@@ -72,9 +103,11 @@ EOC;
                 ));
             }
             $argumentName = $argumentType->getName();
-            $config = $this->createDependencyConfig($config, $argumentName);
-            $config[ConfigAbstractFactory::class][$className][] = $argumentName;
+            $config = $this->createDependencyConfig($config, $argumentName, $ignoreUnresolved);
+            $classConfig[] = $argumentName;
         }
+
+        $config[ConfigAbstractFactory::class][$className] = $classConfig;
 
         return $config;
     }

--- a/src/Tool/ConfigDumperCommand.php
+++ b/src/Tool/ConfigDumperCommand.php
@@ -26,6 +26,8 @@ class ConfigDumperCommand
 <info>Arguments:</info>
 
   <info>-h|--help|help</info>    This usage message
+  <info>-i|--ignore-unresolved</info>    Ignore classes with unresolved
+                    direct dependencies.
   <info><configFile></info>      Path to a config file for which to generate configuration.
                     If the file does not exist, it will be created. If it does
                     exist, it must return an array, and the file will be
@@ -81,7 +83,11 @@ EOH;
 
         $dumper = new ConfigDumper();
         try {
-            $config = $dumper->createDependencyConfig($arguments->config, $arguments->class);
+            $config = $dumper->createDependencyConfig(
+                $arguments->config,
+                $arguments->class,
+                $arguments->ignoreUnresolved
+            );
         } catch (Exception\InvalidArgumentException $e) {
             $this->helper->writeErrorMessage(sprintf(
                 'Unable to create config for "%s": %s',
@@ -115,6 +121,12 @@ EOH;
 
         if (in_array($arg1, ['-h', '--help', 'help'], true)) {
             return $this->createHelpArgument();
+        }
+
+        $ignoreUnresolved = false;
+        if (in_array($arg1, ['-i', '--ignore-unresolved'], true)) {
+            $ignoreUnresolved = true;
+            $arg1 = array_shift($args);
         }
 
         if (! count($args)) {
@@ -157,7 +169,7 @@ EOH;
             ));
         }
 
-        return $this->createArguments(self::COMMAND_DUMP, $configFile, $config, $class);
+        return $this->createArguments(self::COMMAND_DUMP, $configFile, $config, $class, $ignoreUnresolved);
     }
 
     /**
@@ -178,15 +190,17 @@ EOH;
      *     which it will be written.
      * @param array $config Parsed configuration.
      * @param string $class Name of class to reflect.
+     * @param bool $ignoreUnresolved If to ignore classes with unresolved direct dependencies.
      * @return \stdClass
      */
-    private function createArguments($command, $configFile, $config, $class)
+    private function createArguments($command, $configFile, $config, $class, $ignoreUnresolved)
     {
         return (object) [
-            'command'    => $command,
-            'configFile' => $configFile,
-            'config'     => $config,
-            'class'      => $class,
+            'command'          => $command,
+            'configFile'       => $configFile,
+            'config'           => $config,
+            'class'            => $class,
+            'ignoreUnresolved' => $ignoreUnresolved,
         ];
     }
 

--- a/test/TestAsset/ObjectWithObjectScalarDependency.php
+++ b/test/TestAsset/ObjectWithObjectScalarDependency.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+class ObjectWithObjectScalarDependency
+{
+    public function __construct(SimpleDependencyObject $simpleDependencyObject, ObjectWithScalarDependency $dependency)
+    {
+    }
+}


### PR DESCRIPTION
*Trying to resolve missed cache using `ReflectionBasedAbstractFactory` generating config mappings for a whole module/project.*

### Skipping classes with unresolved dependencies

Added ability to ignore only classed with direct unresolved dependencies in ConfigDumper command.

At this moment, `generate-deps-for-config-factory` command throws an exception if just one dependency in the the dependency tree could not be resolved.

Adding a parameter `-i|--ignore-unresolved` it will not add the definition of the class with an unresolved dependency, but continuing the execution adding other dependency definitions.

Consider these classes:

```php
namespace TestAsset;

class ObjectWithObjectScalarDependency
{
    public function __construct(
        SimpleDependencyObject $simpleDependencyObject,
        ObjectWithScalarDependency $dependency,
        TestInterface $interface
)  {
    }
}

class SimpleDependencyObject
{
    public function __construct(InvokableObject $invokableObject)
    {
    }
}

class ObjectWithScalarDependency
{
    public function __construct($aName)
    {
    }
}

class InvokableObject
{
    public function __construct(array $options = [])
    {
        $this->options = $options;
    }
}

interface TestInterface
{
}

```

Dependency tree:
```
+ ObjectWithObjectScalarDependency
|
+---> SimpleDependencyObject
|     |
|     +---> InvokableObject
|
+---> ObjectWithScalarDependency
|     |
|     +---> $aName (scalar)
|
+---> TestInterface (interface)
```

Command:
```
$ generate-deps-for-config-factory ./config.php TestAsset\ObjectWithObjectScalarDependency
```

This command will write nothing. An exception will throw.

Command:
```
$ generate-deps-for-config-factory --ignore-unresolved ./config.php TestAsset\ObjectWithObjectScalarDependency
```

This command will generate a config with the following mapping config:

```php
$config = [
    ObjectWithObjectScalarDependency::class => [
        SimpleDependencyObject::class,
        ObjectWithScalarDependency::class,
        TestInterface:: class,
    ],
    SimpleDependencyObject::class => [
        InvokableObject::class,
    ],
    InvokableObject::class => [],
];
```

Like for interfaces, classes with unresolved dependencies will be included in other classes dependencies, but no definitions will be written.

This will be useful to generate something similar a cache for a whole project/module.

The idea is to do something like this:

```
$ find ./module/Auth/src/ -name "*.php" | xargs ./bin/classes-from-file | xargs ./bin/generate-deps-for-config-factory ./config.php
```

### ContainerInterface dependecy in ConfigDumper

I added the ability to inject a `ContainerInterface` in the `ConfigDumper` class.

It's used in `ConfigDumper::createDependencyConfig()`.

If a container is injected, before to throw an exception, it checks if the class with an unresolved dependency is already defined in the container. In this case we can safely skip the dependency definition for this class.

### Considerations

I preferred to don't add a command to get classes in files (scanning a directory) to don't include another dependency in this project.