### PR TITLE
phpunit 4 parts removed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "ocramius/proxy-manager": "^1.0 || ^2.0",
         "phpbench/phpbench": "^0.10.0",
-        "phpunit/phpunit": "^5.2.10",
+        "phpunit/phpunit": "^5.7 || ^6.0.6",
         "mikey179/vfsStream": "^1.6",
         "zendframework/zend-coding-standard": "~1.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "ocramius/proxy-manager": "^1.0 || ^2.0",
         "phpbench/phpbench": "^0.10.0",
-        "phpunit/phpunit": "^4.6 || ^5.2.10",
+        "phpunit/phpunit": "^5.2.10",
         "mikey179/vfsStream": "^1.6",
         "zendframework/zend-coding-standard": "~1.0.0"
     },

--- a/src/Test/CommonPluginManagerTrait.php
+++ b/src/Test/CommonPluginManagerTrait.php
@@ -53,7 +53,7 @@ trait CommonPluginManagerTrait
 
     public function testRegisteringInvalidElementRaisesException()
     {
-        $this->setExpectedException($this->getServiceNotFoundException());
+        $this->expectException($this->getServiceNotFoundException());
         $this->getPluginManager()->setService('test', $this);
     }
 
@@ -61,7 +61,7 @@ trait CommonPluginManagerTrait
     {
         $manager = $this->getPluginManager();
         $manager->setInvokableClass('test', get_class($this));
-        $this->setExpectedException($this->getServiceNotFoundException());
+        $this->expectException($this->getServiceNotFoundException());
         $manager->get('test');
     }
 

--- a/test/AbstractFactory/ConfigAbstractFactoryTest.php
+++ b/test/AbstractFactory/ConfigAbstractFactoryTest.php
@@ -7,6 +7,7 @@
 
 namespace ZendTest\ServiceManager\AbstractFactory;
 
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractFactory\ConfigAbstractFactory;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\ServiceManager;
@@ -15,7 +16,7 @@ use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\SecondComplexDependencyObject;
 use ZendTest\ServiceManager\TestAsset\SimpleDependencyObject;
 
-class ConfigAbstractFactoryTest extends \PHPUnit\Framework\TestCase
+class ConfigAbstractFactoryTest extends TestCase
 {
 
     public function testCanCreateReturnsTrueIfDependencyNotArrays()

--- a/test/AbstractFactory/ConfigAbstractFactoryTest.php
+++ b/test/AbstractFactory/ConfigAbstractFactoryTest.php
@@ -15,7 +15,7 @@ use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\SecondComplexDependencyObject;
 use ZendTest\ServiceManager\TestAsset\SimpleDependencyObject;
 
-class ConfigAbstractFactoryTest extends \PHPUnit_Framework_TestCase
+class ConfigAbstractFactoryTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testCanCreateReturnsTrueIfDependencyNotArrays()

--- a/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
+++ b/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
@@ -8,7 +8,7 @@
 namespace ZendTest\ServiceManager\AbstractFactory;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Zend\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 
@@ -55,13 +55,11 @@ class ReflectionBasedAbstractFactoryTest extends TestCase
         $this->container->has('config')->willReturn(false);
         $factory = new ReflectionBasedAbstractFactory();
         $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage(
-            sprintf(
-                'Unable to create service "%s"; unable to resolve parameter "sample" using type hint "%s"',
-                TestAsset\ClassWithTypeHintedConstructorParameter::class,
-                TestAsset\SampleInterface::class
-            )
-        );
+        $this->expectExceptionMessage(sprintf(
+            'Unable to create service "%s"; unable to resolve parameter "sample" using type hint "%s"',
+            TestAsset\ClassWithTypeHintedConstructorParameter::class,
+            TestAsset\SampleInterface::class
+        ));
         $factory($this->container->reveal(), TestAsset\ClassWithTypeHintedConstructorParameter::class);
     }
 
@@ -69,12 +67,10 @@ class ReflectionBasedAbstractFactoryTest extends TestCase
     {
         $factory = new ReflectionBasedAbstractFactory();
         $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage(
-            sprintf(
-                'Unable to create service "%s"; unable to resolve parameter "foo" to a class, interface, or array type',
-                TestAsset\ClassWithScalarParameters::class
-            )
-        );
+        $this->expectExceptionMessage(sprintf(
+            'Unable to create service "%s"; unable to resolve parameter "foo" to a class, interface, or array type',
+            TestAsset\ClassWithScalarParameters::class
+        ));
         $instance = $factory($this->container->reveal(), TestAsset\ClassWithScalarParameters::class);
     }
 

--- a/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
+++ b/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
@@ -54,8 +54,8 @@ class ReflectionBasedAbstractFactoryTest extends TestCase
         $this->container->has(TestAsset\SampleInterface::class)->willReturn(false);
         $this->container->has('config')->willReturn(false);
         $factory = new ReflectionBasedAbstractFactory();
-        $this->setExpectedException(
-            ServiceNotFoundException::class,
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage(
             sprintf(
                 'Unable to create service "%s"; unable to resolve parameter "sample" using type hint "%s"',
                 TestAsset\ClassWithTypeHintedConstructorParameter::class,
@@ -68,8 +68,8 @@ class ReflectionBasedAbstractFactoryTest extends TestCase
     public function testFactoryRaisesExceptionForScalarParameters()
     {
         $factory = new ReflectionBasedAbstractFactory();
-        $this->setExpectedException(
-            ServiceNotFoundException::class,
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage(
             sprintf(
                 'Unable to create service "%s"; unable to resolve parameter "foo" to a class, interface, or array type',
                 TestAsset\ClassWithScalarParameters::class

--- a/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
+++ b/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
@@ -8,7 +8,7 @@
 namespace ZendTest\ServiceManager\AbstractFactory;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -8,7 +8,7 @@
 namespace ZendTest\ServiceManager;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\ServiceManager\ConfigInterface;
 use Zend\ServiceManager\Exception\InvalidArgumentException;

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -8,7 +8,7 @@
 namespace ZendTest\ServiceManager;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use stdClass;
 use Zend\ServiceManager\ConfigInterface;
 use Zend\ServiceManager\Exception\InvalidArgumentException;
@@ -181,7 +181,8 @@ class AbstractPluginManagerTest extends TestCase
     public function testGetRaisesExceptionWhenNoFactoryIsResolved()
     {
         $pluginManager = $this->createContainer();
-        $this->expectException(ServiceNotFoundException::class, get_class($pluginManager));
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage(get_class($pluginManager));
         $pluginManager->get('Some\Unknown\Service');
     }
 

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -77,7 +77,7 @@ class AbstractPluginManagerTest extends TestCase
         $pluginManager->get(InvokableObject::class);
 
         // Assert it throws an exception for anything else
-        $this->setExpectedException(InvalidServiceException::class);
+        $this->expectException(InvalidServiceException::class);
         $pluginManager->get(stdClass::class);
     }
 
@@ -181,7 +181,7 @@ class AbstractPluginManagerTest extends TestCase
     public function testGetRaisesExceptionWhenNoFactoryIsResolved()
     {
         $pluginManager = $this->createContainer();
-        $this->setExpectedException(ServiceNotFoundException::class, get_class($pluginManager));
+        $this->expectException(ServiceNotFoundException::class, get_class($pluginManager));
         $pluginManager->get('Some\Unknown\Service');
     }
 
@@ -259,7 +259,7 @@ class AbstractPluginManagerTest extends TestCase
      */
     public function testPassingNonContainerNonConfigNonNullFirstConstructorArgumentRaisesException($arg)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         new TestAsset\LenientPluginManager($arg);
     }
 
@@ -308,7 +308,8 @@ class AbstractPluginManagerTest extends TestCase
     public function testPluginManagersMayOptOutOfSupportingAutoInvokableServices()
     {
         $pluginManager = new TestAsset\NonAutoInvokablePluginManager(new ServiceManager());
-        $this->setExpectedException(ServiceNotFoundException::class, TestAsset\NonAutoInvokablePluginManager::class);
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage(TestAsset\NonAutoInvokablePluginManager::class);
         $pluginManager->get(TestAsset\InvokableObject::class);
     }
 
@@ -342,14 +343,14 @@ class AbstractPluginManagerTest extends TestCase
     public function testSetServiceShouldRaiseExceptionForInvalidPlugin()
     {
         $pluginManager = new TestAsset\SimplePluginManager(new ServiceManager());
-        $this->setExpectedException(InvalidServiceException::class);
+        $this->expectException(InvalidServiceException::class);
         $pluginManager->setService(stdClass::class, new stdClass());
     }
 
     public function testPassingServiceInstanceViaConfigureShouldRaiseExceptionForInvalidPlugin()
     {
         $pluginManager = new TestAsset\SimplePluginManager(new ServiceManager());
-        $this->setExpectedException(InvalidServiceException::class);
+        $this->expectException(InvalidServiceException::class);
         $pluginManager->configure(['services' => [
             stdClass::class => new stdClass(),
         ]]);

--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -136,7 +136,7 @@ trait CommonServiceLocatorBehaviorsTrait
             ]
         ]);
 
-        $serviceManager->get(DateTime::class);
+        $this->assertInstanceOf(DateTime::class, $serviceManager->get(DateTime::class));
     }
 
     public function testAllowsMultipleInstancesOfTheSameAbstractFactory()
@@ -258,7 +258,7 @@ trait CommonServiceLocatorBehaviorsTrait
             ]
         ]);
 
-        $this->setExpectedException(ServiceNotCreatedException::class);
+        $this->expectException(ServiceNotCreatedException::class);
 
         $serviceManager->get(stdClass::class);
     }
@@ -271,7 +271,7 @@ trait CommonServiceLocatorBehaviorsTrait
             ]
         ]);
 
-        $this->setExpectedException(ServiceNotCreatedException::class);
+        $this->expectException(ServiceNotCreatedException::class);
 
         $serviceManager->get(stdClass::class);
     }
@@ -512,7 +512,8 @@ trait CommonServiceLocatorBehaviorsTrait
         $factory,
         $contains = 'invalid abstract factory'
     ) {
-        $this->setExpectedException(InvalidArgumentException::class, $contains);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($contains);
         $serviceManager = $this->createContainer([
             'abstract_factories' => [
                 $factory,
@@ -552,7 +553,8 @@ trait CommonServiceLocatorBehaviorsTrait
         $initializer,
         $contains = 'invalid initializer'
     ) {
-        $this->setExpectedException(InvalidArgumentException::class, $contains);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($contains);
         $serviceManager = $this->createContainer([
             'initializers' => [
                 $initializer,
@@ -566,7 +568,8 @@ trait CommonServiceLocatorBehaviorsTrait
     public function testGetRaisesExceptionWhenNoFactoryIsResolved()
     {
         $serviceManager = $this->createContainer();
-        $this->setExpectedException(ContainerException::class, 'Unable to resolve');
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessage('Unable to resolve');
         $serviceManager->get('Some\Unknown\Service');
     }
 
@@ -600,7 +603,8 @@ trait CommonServiceLocatorBehaviorsTrait
             ],
         ]);
 
-        $this->setExpectedException(ServiceNotCreatedException::class, $contains);
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage($contains);
         $serviceManager->get(stdClass::class);
     }
 
@@ -799,7 +803,7 @@ trait CommonServiceLocatorBehaviorsTrait
     {
         $container = $this->createContainer(['services' => ['foo' => $this]]);
         $container->setAllowOverride(false);
-        $this->setExpectedException(ContainerModificationsNotAllowedException::class);
+        $this->expectException(ContainerModificationsNotAllowedException::class);
         call_user_func_array([$container, $method], $args);
     }
 
@@ -841,7 +845,7 @@ trait CommonServiceLocatorBehaviorsTrait
      */
     public function testCrashesOnCyclicAliases()
     {
-        $this->setExpectedException(CyclicAliasException::class);
+        $this->expectException(CyclicAliasException::class);
 
         $this->createContainer([
             'aliases' => [

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\ServiceManager;
 
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
 

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\ServiceManager;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
 

--- a/test/ExamplePluginManagerTest.php
+++ b/test/ExamplePluginManagerTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\ServiceManager;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;

--- a/test/ExamplePluginManagerTest.php
+++ b/test/ExamplePluginManagerTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\ServiceManager;
 
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;

--- a/test/Exception/CyclicAliasExceptionTest.php
+++ b/test/Exception/CyclicAliasExceptionTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\ServiceManager\Exception;
 
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\Exception\CyclicAliasException;
 
 /**

--- a/test/Exception/CyclicAliasExceptionTest.php
+++ b/test/Exception/CyclicAliasExceptionTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\ServiceManager\Exception;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Zend\ServiceManager\Exception\CyclicAliasException;
 
 /**

--- a/test/Factory/InvokableFactoryTest.php
+++ b/test/Factory/InvokableFactoryTest.php
@@ -8,7 +8,7 @@
 namespace ZendTest\ServiceManager\Factory;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\Factory\InvokableFactory;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 

--- a/test/Factory/InvokableFactoryTest.php
+++ b/test/Factory/InvokableFactoryTest.php
@@ -8,7 +8,7 @@
 namespace ZendTest\ServiceManager\Factory;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Zend\ServiceManager\Factory\InvokableFactory;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 

--- a/test/LazyServiceIntegrationTest.php
+++ b/test/LazyServiceIntegrationTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\ServiceManager;
 
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ProxyManager\Autoloader\AutoloaderInterface;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;

--- a/test/LazyServiceIntegrationTest.php
+++ b/test/LazyServiceIntegrationTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\ServiceManager;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use ProxyManager\Autoloader\AutoloaderInterface;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;

--- a/test/LazyServiceIntegrationTest.php
+++ b/test/LazyServiceIntegrationTest.php
@@ -162,7 +162,8 @@ class LazyServiceIntegrationTest extends TestCase
         ];
 
         $container = new ServiceManager($config);
-        $this->setExpectedException(ServiceNotCreatedException::class, 'class_map');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('class_map');
         $container->get(InvokableObject::class);
     }
 
@@ -277,7 +278,8 @@ class LazyServiceIntegrationTest extends TestCase
 
         $container = new ServiceManager($config);
 
-        $this->setExpectedException(ServiceNotFoundException::class, 'not found in the provided services map');
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('not found in the provided services map');
         $container->build(InvokableObject::class, ['foo' => 'bar']);
     }
 

--- a/test/Proxy/LazyServiceFactoryTest.php
+++ b/test/Proxy/LazyServiceFactoryTest.php
@@ -64,10 +64,8 @@ class LazyServiceFactoryTest extends TestCase
         $this->proxyFactory->expects($this->never())
             ->method('createProxy')
         ;
-        $this->setExpectedException(
-            ServiceNotFoundException::class,
-            'The requested service "not_exists" was not found in the provided services map'
-        );
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('The requested service "not_exists" was not found in the provided services map');
 
         $this->factory->__invoke($container, 'not_exists', [$callback, 'callback']);
     }

--- a/test/Proxy/LazyServiceFactoryTest.php
+++ b/test/Proxy/LazyServiceFactoryTest.php
@@ -9,7 +9,7 @@ namespace ZendTest\ServiceManager\Proxy;
 
 use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use ProxyManager\Proxy\VirtualProxyInterface;

--- a/test/Proxy/LazyServiceFactoryTest.php
+++ b/test/Proxy/LazyServiceFactoryTest.php
@@ -9,7 +9,7 @@ namespace ZendTest\ServiceManager\Proxy;
 
 use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use ProxyManager\Proxy\VirtualProxyInterface;

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -8,7 +8,7 @@
 namespace ZendTest\ServiceManager;
 
 use DateTime;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\Factory\InvokableFactory;

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -8,7 +8,7 @@
 namespace ZendTest\ServiceManager;
 
 use DateTime;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use stdClass;
 use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\Factory\InvokableFactory;

--- a/test/Tool/ConfigDumperCommandTest.php
+++ b/test/Tool/ConfigDumperCommandTest.php
@@ -9,7 +9,7 @@ namespace ZendTest\ServiceManager\Tool;
 
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Prophecy\Argument;
 use Zend\ServiceManager\AbstractFactory\ConfigAbstractFactory;
 use Zend\ServiceManager\Tool\ConfigDumperCommand;

--- a/test/Tool/ConfigDumperCommandTest.php
+++ b/test/Tool/ConfigDumperCommandTest.php
@@ -9,7 +9,7 @@ namespace ZendTest\ServiceManager\Tool;
 
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Zend\ServiceManager\AbstractFactory\ConfigAbstractFactory;
 use Zend\ServiceManager\Tool\ConfigDumperCommand;

--- a/test/Tool/ConfigDumperTest.php
+++ b/test/Tool/ConfigDumperTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\ServiceManager\Tool;
 
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractFactory\ConfigAbstractFactory;
 use Zend\ServiceManager\Exception\InvalidArgumentException;
 use Zend\ServiceManager\Factory\FactoryInterface;

--- a/test/Tool/ConfigDumperTest.php
+++ b/test/Tool/ConfigDumperTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\ServiceManager\Tool;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Zend\ServiceManager\AbstractFactory\ConfigAbstractFactory;
 use Zend\ServiceManager\Exception\InvalidArgumentException;
 use Zend\ServiceManager\Factory\FactoryInterface;

--- a/test/Tool/FactoryCreatorCommandTest.php
+++ b/test/Tool/FactoryCreatorCommandTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\ServiceManager\Tool;
 
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\Tool\FactoryCreatorCommand;

--- a/test/Tool/FactoryCreatorCommandTest.php
+++ b/test/Tool/FactoryCreatorCommandTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\ServiceManager\Tool;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Prophecy\Argument;
 use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\Tool\FactoryCreatorCommand;

--- a/test/Tool/FactoryCreatorTest.php
+++ b/test/Tool/FactoryCreatorTest.php
@@ -7,12 +7,13 @@
 
 namespace ZendTest\ServiceManager\Tool;
 
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\Tool\FactoryCreator;
 use ZendTest\ServiceManager\TestAsset\ComplexDependencyObject;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\SimpleDependencyObject;
 
-class FactoryCreatorTest extends \PHPUnit\Framework\TestCase
+class FactoryCreatorTest extends TestCase
 {
     /**
      * @var FactoryCreator

--- a/test/Tool/FactoryCreatorTest.php
+++ b/test/Tool/FactoryCreatorTest.php
@@ -12,7 +12,7 @@ use ZendTest\ServiceManager\TestAsset\ComplexDependencyObject;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\SimpleDependencyObject;
 
-class FactoryCreatorTest extends \PHPUnit_Framework_TestCase
+class FactoryCreatorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var FactoryCreator


### PR DESCRIPTION
removed old PHPUnit4 Parts
changed `setExpectedException` to `expectException` and `expectExceptionMessage`
added in `testCanCreateServiceWithAbstractFactory` a assert
added PHPUnit6, thanks to @webimpress for the hint=)