### PR TITLE
Import PHP internal functions

### DIFF
--- a/benchmarks/BenchAsset/AbstractFactoryFoo.php
+++ b/benchmarks/BenchAsset/AbstractFactoryFoo.php
@@ -7,8 +7,8 @@
 
 namespace ZendBench\ServiceManager\BenchAsset;
 
-use Zend\ServiceManager\Factory\AbstractFactoryInterface;
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\AbstractFactoryInterface;
 
 class AbstractFactoryFoo implements AbstractFactoryInterface
 {

--- a/benchmarks/BenchAsset/FactoryFoo.php
+++ b/benchmarks/BenchAsset/FactoryFoo.php
@@ -7,8 +7,8 @@
 
 namespace ZendBench\ServiceManager\BenchAsset;
 
-use Zend\ServiceManager\Factory\FactoryInterface;
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\FactoryInterface;
 
 class FactoryFoo implements FactoryInterface
 {

--- a/src/AbstractFactory/ConfigAbstractFactory.php
+++ b/src/AbstractFactory/ConfigAbstractFactory.php
@@ -11,6 +11,12 @@ use ArrayObject;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\Factory\AbstractFactoryInterface;
 
+use function array_key_exists;
+use function array_map;
+use function array_values;
+use function is_array;
+use function json_encode;
+
 final class ConfigAbstractFactory implements AbstractFactoryInterface
 {
 

--- a/src/AbstractFactory/ReflectionBasedAbstractFactory.php
+++ b/src/AbstractFactory/ReflectionBasedAbstractFactory.php
@@ -13,6 +13,10 @@ use ReflectionParameter;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\Factory\AbstractFactoryInterface;
 
+use function array_map;
+use function class_exists;
+use function sprintf;
+
 /**
  * Reflection-based factory.
  *

--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -10,6 +10,14 @@ namespace Zend\ServiceManager;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 
+use function class_exists;
+use function get_class;
+use function gettype;
+use function is_object;
+use function method_exists;
+use function sprintf;
+use function trigger_error;
+
 /**
  * Abstract plugin manager.
  *

--- a/src/Config.php
+++ b/src/Config.php
@@ -10,6 +10,11 @@ namespace Zend\ServiceManager;
 use Zend\Stdlib\ArrayUtils\MergeRemoveKey;
 use Zend\Stdlib\ArrayUtils\MergeReplaceKeyInterface;
 
+use function array_key_exists;
+use function array_keys;
+use function is_array;
+use function is_int;
+
 /**
  * Object for defining configuration and configuring an existing service manager instance.
  *

--- a/src/Exception/CyclicAliasException.php
+++ b/src/Exception/CyclicAliasException.php
@@ -7,6 +7,16 @@
 
 namespace Zend\ServiceManager\Exception;
 
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_values;
+use function implode;
+use function reset;
+use function serialize;
+use function sort;
+use function sprintf;
+
 class CyclicAliasException extends InvalidArgumentException
 {
     /**

--- a/src/Proxy/LazyServiceFactory.php
+++ b/src/Proxy/LazyServiceFactory.php
@@ -13,6 +13,8 @@ use ProxyManager\Proxy\LazyLoadingInterface;
 use Zend\ServiceManager\Exception;
 use Zend\ServiceManager\Factory\DelegatorFactoryInterface;
 
+use function sprintf;
+
 /**
  * Delegator factory responsible of instantiating lazy loading value holder proxies of
  * given services at runtime

--- a/src/ServiceLocatorInterface.php
+++ b/src/ServiceLocatorInterface.php
@@ -7,9 +7,9 @@
 
 namespace Zend\ServiceManager;
 
-use Psr\Container\ContainerInterface as PsrContainerInterface;
-use Psr\Container\ContainerExceptionInterface;
 use Interop\Container\ContainerInterface as InteropContainerInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
 
 /**
  * Interface for service locator

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -21,6 +21,22 @@ use Zend\ServiceManager\Exception\InvalidArgumentException;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 
+use function array_intersect_key;
+use function array_keys;
+use function array_merge;
+use function array_merge_recursive;
+use function class_exists;
+use function get_class;
+use function gettype;
+use function implode;
+use function is_callable;
+use function is_object;
+use function is_string;
+use function spl_autoload_register;
+use function spl_object_hash;
+use function sprintf;
+use function trigger_error;
+
 /**
  * Service Manager.
  *
@@ -392,8 +408,8 @@ class ServiceManager implements ServiceLocatorInterface
         }
 
         // Performance optimization. If there are no collisions, then we don't need to recompute loops
-        $intersecting  = $this->aliases && \array_intersect_key($this->aliases, $aliases);
-        $this->aliases = $this->aliases ? \array_merge($this->aliases, $aliases) : $aliases;
+        $intersecting  = $this->aliases && array_intersect_key($this->aliases, $aliases);
+        $this->aliases = $this->aliases ? array_merge($this->aliases, $aliases) : $aliases;
 
         if ($intersecting) {
             $this->resolveAliases($this->aliases);

--- a/src/Test/CommonPluginManagerTrait.php
+++ b/src/Test/CommonPluginManagerTrait.php
@@ -11,6 +11,9 @@ use ReflectionClass;
 use ReflectionProperty;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 
+use function get_class;
+use function method_exists;
+
 /**
  * Trait for testing plugin managers for v2-v3 compatibility
  *

--- a/src/Tool/ConfigDumper.php
+++ b/src/Tool/ConfigDumper.php
@@ -14,6 +14,22 @@ use Traversable;
 use Zend\ServiceManager\AbstractFactory\ConfigAbstractFactory;
 use Zend\ServiceManager\Exception\InvalidArgumentException;
 
+use function array_filter;
+use function array_key_exists;
+use function class_exists;
+use function date;
+use function get_class;
+use function gettype;
+use function implode;
+use function interface_exists;
+use function is_array;
+use function is_int;
+use function is_null;
+use function is_string;
+use function sprintf;
+use function str_repeat;
+use function var_export;
+
 class ConfigDumper
 {
     const CONFIG_TEMPLATE = <<<EOC

--- a/src/Tool/ConfigDumperCommand.php
+++ b/src/Tool/ConfigDumperCommand.php
@@ -10,6 +10,17 @@ namespace Zend\ServiceManager\Tool;
 use Zend\ServiceManager\Exception;
 use Zend\Stdlib\ConsoleHelper;
 
+use function array_shift;
+use function class_exists;
+use function count;
+use function dirname;
+use function file_exists;
+use function file_put_contents;
+use function in_array;
+use function is_array;
+use function is_writable;
+use function sprintf;
+
 class ConfigDumperCommand
 {
     const COMMAND_DUMP = 'dump';

--- a/src/Tool/FactoryCreator.php
+++ b/src/Tool/FactoryCreator.php
@@ -11,6 +11,17 @@ use ReflectionClass;
 use ReflectionParameter;
 use Zend\ServiceManager\Exception\InvalidArgumentException;
 
+use function array_filter;
+use function array_map;
+use function array_shift;
+use function count;
+use function implode;
+use function sprintf;
+use function str_repeat;
+use function str_replace;
+use function strrpos;
+use function substr;
+
 class FactoryCreator
 {
     const FACTORY_TEMPLATE = <<<'EOT'

--- a/src/Tool/FactoryCreatorCommand.php
+++ b/src/Tool/FactoryCreatorCommand.php
@@ -10,6 +10,12 @@ namespace Zend\ServiceManager\Tool;
 use Zend\ServiceManager\Exception;
 use Zend\Stdlib\ConsoleHelper;
 
+use function array_shift;
+use function class_exists;
+use function count;
+use function in_array;
+use function sprintf;
+
 class FactoryCreatorCommand
 {
     const COMMAND_DUMP = 'dump';

--- a/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
+++ b/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
@@ -12,6 +12,8 @@ use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 
+use function sprintf;
+
 class ReflectionBasedAbstractFactoryTest extends TestCase
 {
     public function setUp()

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -22,6 +22,10 @@ use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\SimplePluginManager;
 use ZendTest\ServiceManager\TestAsset\V2v3PluginManager;
 
+use function get_class;
+use function restore_error_handler;
+use function set_error_handler;
+
 /**
  * @covers \Zend\ServiceManager\AbstractPluginManager
  */

--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -26,6 +26,10 @@ use ZendTest\ServiceManager\TestAsset\FailingExceptionWithStringAsCodeFactory;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\SimpleAbstractFactory;
 
+use function call_user_func_array;
+use function restore_error_handler;
+use function set_error_handler;
+
 trait CommonServiceLocatorBehaviorsTrait
 {
     /**

--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -21,8 +21,8 @@ use Zend\ServiceManager\Initializer\InitializerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZendTest\ServiceManager\TestAsset\CallTimesAbstractFactory;
 use ZendTest\ServiceManager\TestAsset\FailingAbstractFactory;
-use ZendTest\ServiceManager\TestAsset\FailingFactory;
 use ZendTest\ServiceManager\TestAsset\FailingExceptionWithStringAsCodeFactory;
+use ZendTest\ServiceManager\TestAsset\FailingFactory;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\SimpleAbstractFactory;
 

--- a/test/LazyServiceIntegrationTest.php
+++ b/test/LazyServiceIntegrationTest.php
@@ -21,6 +21,21 @@ use Zend\ServiceManager\Proxy\LazyServiceFactory;
 use Zend\ServiceManager\ServiceManager;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 
+use function array_filter;
+use function closedir;
+use function get_class;
+use function is_dir;
+use function is_file;
+use function iterator_to_array;
+use function mkdir;
+use function opendir;
+use function readdir;
+use function rmdir;
+use function spl_autoload_functions;
+use function spl_autoload_unregister;
+use function sys_get_temp_dir;
+use function unlink;
+
 /**
  * @covers \Zend\ServiceManager\ServiceManager
  */

--- a/test/Proxy/LazyServiceFactoryTest.php
+++ b/test/Proxy/LazyServiceFactoryTest.php
@@ -8,8 +8,8 @@
 namespace ZendTest\ServiceManager\Proxy;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use ProxyManager\Proxy\VirtualProxyInterface;

--- a/test/TestAsset/V2ValidationPluginManager.php
+++ b/test/TestAsset/V2ValidationPluginManager.php
@@ -10,6 +10,10 @@ namespace ZendTest\ServiceManager\TestAsset;
 use RuntimeException;
 use Zend\ServiceManager\AbstractPluginManager;
 
+use function call_user_func;
+use function is_callable;
+use function sprintf;
+
 class V2ValidationPluginManager extends AbstractPluginManager
 {
     public $assertion;

--- a/test/TestAsset/V2v3PluginManager.php
+++ b/test/TestAsset/V2v3PluginManager.php
@@ -11,6 +11,9 @@ use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\Factory\InvokableFactory;
 
+use function get_class;
+use function sprintf;
+
 class V2v3PluginManager extends AbstractPluginManager
 {
     protected $aliases = [

--- a/test/Tool/ConfigDumperCommandTest.php
+++ b/test/Tool/ConfigDumperCommandTest.php
@@ -18,6 +18,10 @@ use ZendTest\ServiceManager\TestAsset\ObjectWithObjectScalarDependency;
 use ZendTest\ServiceManager\TestAsset\ObjectWithScalarDependency;
 use ZendTest\ServiceManager\TestAsset\SimpleDependencyObject;
 
+use function file_get_contents;
+use function realpath;
+use function sprintf;
+
 class ConfigDumperCommandTest extends TestCase
 {
     public function setUp()

--- a/test/Tool/ConfigDumperTest.php
+++ b/test/Tool/ConfigDumperTest.php
@@ -22,6 +22,11 @@ use ZendTest\ServiceManager\TestAsset\ObjectWithScalarDependency;
 use ZendTest\ServiceManager\TestAsset\SecondComplexDependencyObject;
 use ZendTest\ServiceManager\TestAsset\SimpleDependencyObject;
 
+use function file_put_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
 class ConfigDumperTest extends TestCase
 {
     /**

--- a/test/Tool/FactoryCreatorCommandTest.php
+++ b/test/Tool/FactoryCreatorCommandTest.php
@@ -15,6 +15,9 @@ use Zend\Stdlib\ConsoleHelper;
 use ZendTest\ServiceManager\TestAsset\ObjectWithScalarDependency;
 use ZendTest\ServiceManager\TestAsset\SimpleDependencyObject;
 
+use function file_get_contents;
+use function sprintf;
+
 class FactoryCreatorCommandTest extends TestCase
 {
     public function setUp()

--- a/test/Tool/FactoryCreatorTest.php
+++ b/test/Tool/FactoryCreatorTest.php
@@ -13,6 +13,8 @@ use ZendTest\ServiceManager\TestAsset\ComplexDependencyObject;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\SimpleDependencyObject;
 
+use function file_get_contents;
+
 class FactoryCreatorTest extends TestCase
 {
     /**


### PR DESCRIPTION
As @kynx noticed in #196 we can import internal PHP functions to get the same optimisation in function calls. Changes in this PR are made by sniff from dev of [`zend-coding-standard`](https://github.com/zendframework/zend-coding-standard/pull/1/commits/19e353bb65a32774e9fd40d901587f95e777572b) library and it supersedes #196.

/cc @smuggli @kynx @MichaelGooden @Ocramius @weierophinney 