### PR TITLE
Fix problem with string callables failing in PHP 5.6.

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -669,7 +669,9 @@ class ServiceManager implements ServiceLocatorInterface
                 $this->factories[$name] = $factory;
             }
             // PHP 5.6 fails on 'class::method' callables unless we explode them:
-            if (is_string($factory) && strpos($factory, '::') !== false) {
+            if (PHP_MAJOR_VERSION < 7
+                && is_string($factory) && strpos($factory, '::') !== false
+            ) {
                 $factory = explode('::', $factory);
             }
             return $factory;

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -668,6 +668,10 @@ class ServiceManager implements ServiceLocatorInterface
             if ($lazyLoaded) {
                 $this->factories[$name] = $factory;
             }
+            // PHP 5.6 fails on 'class::method' callables unless we explode them:
+            if (is_string($factory) && strpos($factory, '::') !== false) {
+                $factory = explode('::', $factory);
+            }
             return $factory;
         }
 

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -267,4 +267,20 @@ class ServiceManagerTest extends TestCase
         $this->assertSame($service, $alias);
         $this->assertSame($service, $headAlias);
     }
+
+    public static function sampleFactory()
+    {
+        return new stdClass();
+    }
+
+    public function testStaticCallable()
+    {
+        $config = [
+            'factories' => [
+                stdClass::class => 'ZendTest\ServiceManager\ServiceManagerTest::sampleFactory',
+            ]
+        ];
+        $serviceManager = new SimpleServiceManager($config);
+        $this->assertEquals(stdClass::class, get_class($serviceManager->get(stdClass::class)));
+    }
 }

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -273,7 +273,7 @@ class ServiceManagerTest extends TestCase
         return new stdClass();
     }
 
-    public function testStaticCallable()
+    public function testFactoryMayBeStaticMethodDescribedByCallableString()
     {
         $config = [
             'factories' => [


### PR DESCRIPTION
ServiceManager v2 supported configuring factories to callable strings of the form `'Class::Method'`, as a concise alternative to `['Class', 'Method']`.

ServiceManager v3 continues to support this for PHP 7, but for some reason, the feature breaks in PHP 5.6.

This pull request includes a possible fix as well as a test that demonstrates the problem; without my proposed code changes to the ServiceManager, the test dies with a fatal error in PHP 5.6, but passes in PHP 7.

If there is a more elegant solution, I would welcome feedback. If this support is being dropped intentionally, we should at least find a way to fail more gracefully.