### PR TITLE
Ensure a `null` value is passed to `setCreationOptions` instead of empty array

### DIFF
--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -209,8 +209,8 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group 205
+     * @codingStandardsIgnoreStart
      */
-    // @codingStandardsIgnoreStart
     public function testRetrievingServicesViaFactoryThatUsesCreationOptionsShouldReturnNewInstanceEveryTimeOptionsAreProvided()
     {
         // @codingStandardsIgnoreEnd
@@ -450,5 +450,17 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         $options = ['option' => 'b'];
         $object = $pluginManager->get('foo', $options);
         $this->assertEquals($options, $object->getOptions());
+    }
+
+    public function testIfCreationOptionsAreEmptySetThemThemToNullWhenCreatingAService()
+    {
+        // @codingStandardsIgnoreEnd
+        /** @var $pluginManager AbstractPluginManager */
+        $pluginManager = $this->getMockForAbstractClass('Zend\ServiceManager\AbstractPluginManager');
+        $pluginManager->setFactory(Baz::class, FactoryUsingCreationOptions::class);
+        $pluginManager->setShared(Baz::class, false);
+        $plugin = $pluginManager->get(Baz::class);
+
+        $this->assertNull($plugin->options);
     }
 }

--- a/test/TestAsset/FactoryUsingCreationOptions.php
+++ b/test/TestAsset/FactoryUsingCreationOptions.php
@@ -23,11 +23,11 @@ class FactoryUsingCreationOptions implements FactoryInterface
     }
 
     /**
-     * @param array $creationOptions
+     * @param array|null $creationOptions
      *
      * @return void
      */
-    public function setCreationOptions(array $creationOptions)
+    public function setCreationOptions(array $creationOptions = null)
     {
         $this->creationOptions = $creationOptions;
     }


### PR DESCRIPTION
Per https://github.com/zendframework/zend-servicemanager/issues/159#issuecomment-349339218, the updates in #205 broke a previously fixed edge case whereby `AbstractPluginManager::createServiceViaCallback()` would inject a `null` value to a factory's `setCreationOptions()` method if no instance options were provided; it instead passed an empty array, which broke a number of plugins that relied on a null value being present.

This patch does the following:

- Adds a regression test for the behavior.
- Modifies `AbstractPluginManager::createServiceViaCallback()` to have three distinct behaviors surrounding creation options, in the following order:
  - if the factory is an `InvokableFactory`, it tests if the creation options are an array or non-empty; if not, it passes a `null` value to `setCreationOptions()`.
  - if the factory is an `MutableCreationOptionsInterface`, it tests if the creation options are an array or non-empty; if not, it passes an empty array to `setCreationOptions()`.
  - if the factory implements the `setCreationOptions()` and the creation options are a non-array or non-empty, it reflects the method to determine if the options argument has a default value, using that if present, or an empty array if not.