### PR TITLE
Test and Fix for ServiceManager::get erronously returning shared services

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -185,16 +185,15 @@ class ServiceManager implements ServiceLocatorInterface
 
         $name = isset($this->resolvedAliases[$name]) ? $this->resolvedAliases[$name] : $name;
 
-        // Determine if the alias shoudld be shared
-        $shareAlias = $requestedName !== $name
-            && (($this->sharedByDefault && ! isset($this->shared[$requestedName]))
-            || (isset($this->shared[$requestedName]) && $this->shared[$requestedName]));
-
         // Next, if the alias should be shared, and we have cached the resolved
-        // service, use it.
-        if ($shareAlias && isset($this->services[$name])) {
-            $this->services[$requestedName] = $this->services[$name];
-            return $this->services[$name];
+        // service, use it. If we don't have it, create it.
+        if ($requestedName !== $name
+            && (($this->sharedByDefault && ! isset($this->shared[$requestedName]))
+            || (isset($this->shared[$requestedName]) && $this->shared[$requestedName])))
+        {
+            $this->services[$requestedName] =
+                isset($this->services[$name]) ? $this->services[$name] : $this->doCreate($name);
+            return $this->services[$requestedName];
         }
 
         // At this point, we need to create the instance; we use the resolved
@@ -203,14 +202,8 @@ class ServiceManager implements ServiceLocatorInterface
 
         // Cache it for later, if it is supposed to be shared.
         if (($this->sharedByDefault && ! isset($this->shared[$name]))
-            || (isset($this->shared[$name]) && $this->shared[$name])
-        ) {
+            || (isset($this->shared[$name]) && $this->shared[$name])) {
             $this->services[$name] = $object;
-        }
-
-        // Also do so for aliases; this allows sharing based on service name used.
-        if ($shareAlias) {
-            $this->services[$requestedName] = $object;
         }
 
         return $object;

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -207,7 +207,7 @@ class ServiceManager implements ServiceLocatorInterface
             $this->services[$name] = $object;
         }
 
-            // Also do so for aliases; this allows sharing based on service name used.
+        // Also do so for aliases; this allows sharing based on service name used.
         if ($shareAlias) {
             $this->services[$requestedName] = $object;
         }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -190,7 +190,8 @@ class ServiceManager implements ServiceLocatorInterface
         if (($requestedName !== $name
             && (($this->sharedByDefault && ! isset($this->shared[$requestedName]))
                 || (isset($this->shared[$requestedName]) && $this->shared[$requestedName])))) {
-            $this->services[$requestedName] = isset($this->services[$name]) ? $this->services[$name] : $this->doCreate($name);
+            $this->services[$requestedName] =
+                isset($this->services[$name]) ? $this->services[$name] : $this->doCreate($name);
             return $this->services[$requestedName];
         }
 

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -189,7 +189,8 @@ class ServiceManager implements ServiceLocatorInterface
         // service, use it. If it is not cached, create it.
         if (($requestedName !== $name
             && (($this->sharedByDefault && ! isset($this->shared[$requestedName]))
-                || (isset($this->shared[$requestedName]) && $this->shared[$requestedName])))) {
+                || (isset($this->shared[$requestedName]) && $this->shared[$requestedName]))))
+        {
             $this->services[$requestedName] =
                 isset($this->services[$name]) ? $this->services[$name] : $this->doCreate($name);
             return $this->services[$requestedName];

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -185,12 +185,14 @@ class ServiceManager implements ServiceLocatorInterface
 
         $name = isset($this->resolvedAliases[$name]) ? $this->resolvedAliases[$name] : $name;
 
+        // Determine if the alias shoudld be shared
+        $shareAlias = $requestedName !== $name
+            && (($this->sharedByDefault && ! isset($this->shared[$requestedName]))
+            || (isset($this->shared[$requestedName]) && $this->shared[$requestedName]));
+
         // Next, if the alias should be shared, and we have cached the resolved
         // service, use it.
-        if ($requestedName !== $name
-            && (! isset($this->shared[$requestedName]) || $this->shared[$requestedName])
-            && isset($this->services[$name])
-        ) {
+        if ($shareAlias && isset($this->services[$name])) {
             $this->services[$requestedName] = $this->services[$name];
             return $this->services[$name];
         }
@@ -207,10 +209,7 @@ class ServiceManager implements ServiceLocatorInterface
         }
 
         // Also do so for aliases; this allows sharing based on service name used.
-        if ($requestedName !== $name
-            && (($this->sharedByDefault && ! isset($this->shared[$requestedName]))
-                || (isset($this->shared[$requestedName]) && $this->shared[$requestedName]))
-        ) {
+        if ($shareAlias) {
             $this->services[$requestedName] = $object;
         }
 

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -189,8 +189,7 @@ class ServiceManager implements ServiceLocatorInterface
         // service, use it. If it is not cached, create it.
         if (($requestedName !== $name
             && (($this->sharedByDefault && ! isset($this->shared[$requestedName]))
-                || (isset($this->shared[$requestedName]) && $this->shared[$requestedName]))))
-        {
+                || (isset($this->shared[$requestedName]) && $this->shared[$requestedName])))) {
             $this->services[$requestedName] =
                 isset($this->services[$name]) ? $this->services[$name] : $this->doCreate($name);
             return $this->services[$requestedName];

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -175,34 +175,33 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function get($name)
     {
-        {
-            $requestedName = $name;
+        $requestedName = $name;
 
-            // We start by checking if we have cached the requested service (this
-            // is the fastest method).
+        // We start by checking if we have cached the requested service (this
+        // is the fastest method).
         if (isset($this->services[$requestedName])) {
             return $this->services[$requestedName];
         }
 
-            $name = isset($this->resolvedAliases[$name]) ? $this->resolvedAliases[$name] : $name;
+        $name = isset($this->resolvedAliases[$name]) ? $this->resolvedAliases[$name] : $name;
 
-            // Determine if the alias shoudld be shared
-            $shareAlias = $requestedName !== $name
-                && (($this->sharedByDefault && ! isset($this->shared[$requestedName]))
-                || (isset($this->shared[$requestedName]) && $this->shared[$requestedName]));
+        // Determine if the alias shoudld be shared
+        $shareAlias = $requestedName !== $name
+            && (($this->sharedByDefault && ! isset($this->shared[$requestedName]))
+            || (isset($this->shared[$requestedName]) && $this->shared[$requestedName]));
 
-            // Next, if the alias should be shared, and we have cached the resolved
-            // service, use it.
+        // Next, if the alias should be shared, and we have cached the resolved
+        // service, use it.
         if ($shareAlias && isset($this->services[$name])) {
             $this->services[$requestedName] = $this->services[$name];
             return $this->services[$name];
         }
 
-            // At this point, we need to create the instance; we use the resolved
-            // name for that.
-            $object = $this->doCreate($name);
+        // At this point, we need to create the instance; we use the resolved
+        // name for that.
+        $object = $this->doCreate($name);
 
-            // Cache it for later, if it is supposed to be shared.
+        // Cache it for later, if it is supposed to be shared.
         if (($this->sharedByDefault && ! isset($this->shared[$name]))
                 || (isset($this->shared[$name]) && $this->shared[$name])) {
             $this->services[$name] = $object;
@@ -213,8 +212,7 @@ class ServiceManager implements ServiceLocatorInterface
             $this->services[$requestedName] = $object;
         }
 
-            return $object;
-        }
+        return $object;
     }
 
     /**

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -185,14 +185,12 @@ class ServiceManager implements ServiceLocatorInterface
 
         $name = isset($this->resolvedAliases[$name]) ? $this->resolvedAliases[$name] : $name;
 
-        // Next, if the alias should be shared, and we have cached the resolved
-        // service, use it. If we don't have it, create it.
-        if ($requestedName !== $name
+        // Next, if this is an alias,  and it should be shared, and we have cached the resolved
+        // service, use it. If it is not cached, create it.
+        if (($requestedName !== $name
             && (($this->sharedByDefault && ! isset($this->shared[$requestedName]))
-            || (isset($this->shared[$requestedName]) && $this->shared[$requestedName])))
-        {
-            $this->services[$requestedName] =
-                isset($this->services[$name]) ? $this->services[$name] : $this->doCreate($name);
+                || (isset($this->shared[$requestedName]) && $this->shared[$requestedName])))) {
+            $this->services[$requestedName] = isset($this->services[$name]) ? $this->services[$name] : $this->doCreate($name);
             return $this->services[$requestedName];
         }
 
@@ -202,7 +200,8 @@ class ServiceManager implements ServiceLocatorInterface
 
         // Cache it for later, if it is supposed to be shared.
         if (($this->sharedByDefault && ! isset($this->shared[$name]))
-            || (isset($this->shared[$name]) && $this->shared[$name])) {
+            || (isset($this->shared[$name]) && $this->shared[$name])
+        ) {
             $this->services[$name] = $object;
         }
 

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -203,7 +203,7 @@ class ServiceManager implements ServiceLocatorInterface
 
         // Cache it for later, if it is supposed to be shared.
         if (($this->sharedByDefault && ! isset($this->shared[$name]))
-                || (isset($this->shared[$name]) && $this->shared[$name])) {
+            || (isset($this->shared[$name]) && $this->shared[$name])) {
             $this->services[$name] = $object;
         }
 

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -286,25 +286,23 @@ class ServiceManagerTest extends TestCase
 
     public function testShouldNotShareAliasesWhichAreNotConfiguredToBeShared()
     {
-        $config =
-        [
-            'factories' =>
+        $sm = new ServiceManager(
             [
-                \stdClass::class => InvokableFactory::class,
-            ],
-            'aliases' =>
-            [
-                'alias' => \stdClass::class,
-            ],
-            'shared_by_default' => false,
-            'shared' =>
-            [
-                \stdClass::class => true,
+                'factories' =>
+                [
+                    \stdClass::class => InvokableFactory::class,
+                ],
+                'aliases' =>
+                [
+                    'alias' => \stdClass::class,
+                ],
+                'shared_by_default' => false,
+                'shared' =>
+                [
+                    \stdClass::class => true,
+                ],
             ]
-        ];
-        $sm = new ServiceManager($config);
-        $alias1 = $sm->get('alias');
-        $alias2 = $sm->get('alias');
-        self::assertNotSame($alias1, $alias2);
+        );
+        self::assertNotSame($sm->get('alias'), $sm->get('alias'));
     }
 }

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -288,9 +288,9 @@ class ServiceManagerTest extends TestCase
     {
         $config =
         [
-            'services' =>
+            'factories' =>
             [
-                \stdClass::class => new \stdClass(),
+                \stdClass::class => InvokableFactory::class,
             ],
             'aliases' =>
             [

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -16,6 +16,7 @@ use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\ServiceManager\ServiceManager;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\SimpleServiceManager;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 
 /**
  * @covers \Zend\ServiceManager\ServiceManager
@@ -304,5 +305,32 @@ class ServiceManagerTest extends TestCase
             ]
         );
         self::assertNotSame($sm->get('alias'), $sm->get('alias'));
+    }
+
+    public function testCreateNonSharedAliasServiceFromDirectlyDefinedService()
+    {
+        $sm = new ServiceManager(
+            [
+                'services' =>
+                [
+                    \stdClass::class => new \stdClass(),
+                ],
+                'aliases' =>
+                [
+                    'alias' => \stdClass::class,
+                ],
+                'shared_by_default' => false,
+                'shared' =>
+                [
+                    \stdClass::class => true,
+                ],
+            ]
+        );
+        // Obviously the service manager has to have a factory for
+        // each service which is configured not to be shared
+        // As a delicate detail this applies to alias services as
+        // well if the alias is configured not to be shared
+        self::expectException(ServiceNotFoundException::class);
+        $sm->get('alias');
     }
 }

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -285,7 +285,8 @@ class ServiceManagerTest extends TestCase
     }
 
     public function testShouldNotShareAliasesWhichAreNotConfiguredToBeShared() {
-        $config =            [
+        $config =
+        [
             'factories' =>
             [
                 \stdClass::class => InvokableFactory::class,

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -297,7 +297,8 @@ class ServiceManagerTest extends TestCase
                 'alias' => \stdClass::class,
             ],
             'shared_by_default' => false,
-            'shared' => [
+            'shared' =>
+            [
                 \stdClass::class => true,
             ]
         ];

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -288,9 +288,9 @@ class ServiceManagerTest extends TestCase
     {
         $config =
         [
-            'factories' =>
+            'services' =>
             [
-                \stdClass::class => InvokableFactory::class,
+                \stdClass::class => new \stdClass(),
             ],
             'aliases' =>
             [
@@ -302,23 +302,8 @@ class ServiceManagerTest extends TestCase
             ]
         ];
         $sm = new ServiceManager($config);
-        $service = $sm->get(\stdClass::class);
         $alias1 = $sm->get('alias');
         $alias2 = $sm->get('alias');
-        $msg = '';
-        // to have all errors displayed, allthough
-        // rest is skipped when first assertion fails
-        if ($service === $alias1) {
-            $msg .= "service === alias1 but should be !==\n";
-        }
-        if ($service === $alias2) {
-            $msg .= "service === alias2 but should be !==\n";
-        }
-        if ($alias1 === $alias2) {
-            $msg .= "alias1 === alias2 but should be !==\n";
-        }
-        self::assertNotSame($service, $alias1, $msg);
-        self::assertNotSame($alias1, $alias2, $msg);
-        self::assertNotSame($service, $alias2, $msg);
+        self::assertNotSame($alias1, $alias2);
     }
 }

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -284,7 +284,8 @@ class ServiceManagerTest extends TestCase
         $this->assertEquals(stdClass::class, get_class($serviceManager->get(stdClass::class)));
     }
 
-    public function testShouldNotShareAliasesWhichAreNotConfiguredToBeShared() {
+    public function testShouldNotShareAliasesWhichAreNotConfiguredToBeShared()
+    {
         $config =
         [
             'factories' =>

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -283,4 +283,40 @@ class ServiceManagerTest extends TestCase
         $serviceManager = new SimpleServiceManager($config);
         $this->assertEquals(stdClass::class, get_class($serviceManager->get(stdClass::class)));
     }
+
+    public function testShouldNotShareAliasesWhichAreNotConfiguredToBeShared() {
+        $config =            [
+            'factories' =>
+            [
+                \stdClass::class => InvokableFactory::class,
+            ],
+            'aliases' =>
+            [
+                'alias' => \stdClass::class,
+            ],
+            'shared_by_default' => false,
+            'shared' => [
+                \stdClass::class => true,
+            ]
+        ];
+        $sm = new ServiceManager($config);
+        $service = $sm->get(\stdClass::class);
+        $alias1 = $sm->get('alias');
+        $alias2 = $sm->get('alias');
+        $msg = '';
+        // to have all errors displayed, allthough
+        // rest is skipped when first assertion fails
+        if ($service === $alias1) {
+            $msg .= "service === alias1 but should be !==\n";
+        }
+        if ($service === $alias2) {
+            $msg .= "service === alias2 but should be !==\n";
+        }
+        if ($alias1 === $alias2) {
+            $msg .= "alias1 === alias2 but should be !==\n";
+        }
+        self::assertNotSame($service, $alias1, $msg);
+        self::assertNotSame($alias1, $alias2, $msg);
+        self::assertNotSame($service, $alias2, $msg);
+    }
 }


### PR DESCRIPTION
This PR provides a test and a fix: Under certain conditions the service manager returns a shared service allthough it should not.

To invoke this bug, set shared_by_default to false. Add a factory for a class. Set shared for this class to true. Define an alias for that class. Get an object using the class id. Get an alias (1) using the alias id. Get another alias (2) using the alias id.

Acceptable result would be: object !== alias1 && object !== alias2 && alias1 !== alias2.

Current result is: object === alias1 === alias2, i.e. the returned service is shared.

Note: With a fresh install from master unit tests do not pass. PHPUnit reports 9 errors. With my test case added, it reports 10 errors (most of them related to \n and \r\n string endings, I guess).