### PR TITLE
Remove PHP < 7 fix

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -684,12 +684,7 @@ class ServiceManager implements ServiceLocatorInterface
             if ($lazyLoaded) {
                 $this->factories[$name] = $factory;
             }
-            // PHP 5.6 fails on 'class::method' callables unless we explode them:
-            if (PHP_MAJOR_VERSION < 7
-                && is_string($factory) && strpos($factory, '::') !== false
-            ) {
-                $factory = explode('::', $factory);
-            }
+
             return $factory;
         }
 


### PR DESCRIPTION
In `develop` branch the minimum PHP is 7.1, so this fix is superfluous.