### PR TITLE
Enhancement: Optimize has() performance and add a benchmark for has()

### DIFF
--- a/benchmarks/HasBench.php
+++ b/benchmarks/HasBench.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendBench\ServiceManager;
+
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use Zend\ServiceManager\ServiceManager;
+
+/**
+ * @Revs(1000)
+ * @Iterations(20)
+ * @Warmup(2)
+ */
+class HasBench
+{
+    /**
+     * @var ServiceManager
+     */
+    private $sm;
+
+    public function __construct()
+    {
+        $this->sm = new ServiceManager([
+            'factories' => [
+                'factory1' => BenchAsset\FactoryFoo::class,
+            ],
+            'invokables' => [
+                'invokable1' => BenchAsset\Foo::class,
+            ],
+            'services' => [
+                'service1' => new \stdClass(),
+            ],
+            'aliases' => [
+                'alias1'          => 'service1',
+                'recursiveAlias1' => 'alias1',
+                'recursiveAlias2' => 'recursiveAlias1',
+            ],
+            'abstract_factories' => [
+                BenchAsset\AbstractFactoryFoo::class
+            ]
+        ]);
+
+        // forcing initialization of all the services
+        $this->sm->get('factory1');
+        $this->sm->get('invokable1');
+        $this->sm->get('service1');
+        $this->sm->get('alias1');
+        $this->sm->get('recursiveAlias1');
+        $this->sm->get('recursiveAlias2');
+    }
+
+    public function benchHasFactory1()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+
+        $sm->has('factory1');
+    }
+
+    public function benchHasInvokable1()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+
+        $sm->has('invokable1');
+    }
+
+    public function benchHasService1()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+
+        $sm->has('service1');
+    }
+
+    public function benchHasAlias1()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+
+        $sm->has('alias1');
+    }
+
+    public function benchHasRecursiveAlias1()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+
+        $sm->has('recursiveAlias1');
+    }
+
+    public function benchHasRecursiveAlias2()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+
+        $sm->has('recursiveAlias2');
+    }
+
+    public function benchHasAbstractFactory()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+
+        $sm->has('foo');
+    }
+
+    public function benchHasNot()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+
+        $sm->has('42');
+    }
+}

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -268,8 +268,7 @@ class ServiceManager implements ServiceLocatorInterface
         // Finally check aliases
         $name = $this->resolvedAliases[$name];
         return isset($this->services[$name]) || isset($this->factories[$name]);
-
-     }
+    }
 
     /**
      * Indicate whether or not the instance is immutable.


### PR DESCRIPTION
This PR was merged to #221.

This PR combines #216 and #217 and is based on develop. #216 and #217 were based on master.

It adds a benchmark for has() and reorders has's name resolution to give services, factories and abstract_factories precedence over aliases. 

The benchmark results (against master) show that all requests (even those regarding aliases) gain increased performance.

@Ocramius; Hope, this is ok. Was to lazy to merge the servicemanager.php diffs via rebase. :)

	Dumped result to has.master.xml
	suite: 133ec875223eb1c55bb664c57b1a416a780a9429, date: 2018-01-03, stime: 19:48:57
	+-----------+-------------------------+--------+--------+--------+-----+------------+------------+------------+------------+------------+------------+--------+---------+
	| benchmark | subject                 | groups | params | revs   | its | mem_peak   | best       | mean       | mode       | worst      | stdev      | rstdev | diff    |
	+-----------+-------------------------+--------+--------+--------+-----+------------+------------+------------+------------+------------+------------+--------+---------+
	| HasBench  | benchHasFactory1        |        | []     | 100000 | 100 | 1,383,488b | 0.450000µs | 0.464200µs | 0.460039µs | 0.480000µs | 0.008268µs | 1.78%  | +0.04%  |
	| HasBench  | benchHasInvokable1      |        | []     | 100000 | 100 | 1,383,488b | 0.540000µs | 0.557600µs | 0.559804µs | 0.580000µs | 0.009394µs | 1.68%  | +20.17% |
	| HasBench  | benchHasService1        |        | []     | 100000 | 100 | 1,383,488b | 0.450000µs | 0.464000µs | 0.460098µs | 0.480000µs | 0.008718µs | 1.88%  | 0.00%   |
	| HasBench  | benchHasAlias1          |        | []     | 100000 | 100 | 1,383,480b | 0.550000µs | 0.563800µs | 0.560098µs | 0.590000µs | 0.009673µs | 1.72%  | +21.51% |
	| HasBench  | benchHasRecursiveAlias1 |        | []     | 100000 | 100 | 1,383,488b | 0.570000µs | 0.584100µs | 0.580333µs | 0.610000µs | 0.011233µs | 1.92%  | +25.88% |
	| HasBench  | benchHasRecursiveAlias2 |        | []     | 100000 | 100 | 1,383,488b | 0.570000µs | 0.583500µs | 0.580176µs | 0.610000µs | 0.009421µs | 1.61%  | +25.75% |
	| HasBench  | benchHasAbstractFactory |        | []     | 100000 | 100 | 1,383,488b | 0.800000µs | 0.813400µs | 0.810078µs | 0.850000µs | 0.011851µs | 1.46%  | +75.30% |
	| HasBench  | benchHasNot             |        | []     | 100000 | 100 | 1,383,480b | 0.790000µs | 0.817000µs | 0.812896µs | 0.850000µs | 0.013528µs | 1.66%  | +76.08% |
	+-----------+-------------------------+--------+--------+--------+-----+------------+------------+------------+------------+------------+------------+--------+---------+

	Dumped result to has.216.xml
	suite: 133ec87171d0d0aef2a8a01bd50e09d908c639ae, date: 2018-01-03, stime: 19:36:58
	+-----------+-------------------------+--------+--------+--------+-----+------------+------------+------------+------------+------------+------------+--------+---------+
	| benchmark | subject                 | groups | params | revs   | its | mem_peak   | best       | mean       | mode       | worst      | stdev      | rstdev | diff    |
	+-----------+-------------------------+--------+--------+--------+-----+------------+------------+------------+------------+------------+------------+--------+---------+
	| HasBench  | benchHasFactory1        |        | []     | 100000 | 100 | 1,387,488b | 0.399960µs | 0.415658µs | 0.409999µs | 0.429960µs | 0.007107µs | 1.71%  | 0.00%   |
	| HasBench  | benchHasInvokable1      |        | []     | 100000 | 100 | 1,387,488b | 0.419950µs | 0.430457µs | 0.429816µs | 0.449960µs | 0.009420µs | 2.19%  | +3.56%  |
	| HasBench  | benchHasService1        |        | []     | 100000 | 100 | 1,387,488b | 0.409950µs | 0.419958µs | 0.419934µs | 0.439960µs | 0.008245µs | 1.96%  | +1.03%  |
	| HasBench  | benchHasAlias1          |        | []     | 100000 | 100 | 1,387,480b | 0.419960µs | 0.429996µs | 0.429836µs | 0.450000µs | 0.009274µs | 2.16%  | +3.45%  |
	| HasBench  | benchHasRecursiveAlias1 |        | []     | 100000 | 100 | 1,387,488b | 0.420000µs | 0.435100µs | 0.430098µs | 0.450000µs | 0.008426µs | 1.94%  | +4.68%  |
	| HasBench  | benchHasRecursiveAlias2 |        | []     | 100000 | 100 | 1,387,488b | 0.430000µs | 0.442800µs | 0.440039µs | 0.460000µs | 0.009174µs | 2.07%  | +6.53%  |
	| HasBench  | benchHasAbstractFactory |        | []     | 100000 | 100 | 1,387,488b | 0.690000µs | 0.707800µs | 0.709472µs | 0.740000µs | 0.010352µs | 1.46%  | +70.28% |
	| HasBench  | benchHasNot             |        | []     | 100000 | 100 | 1,387,480b | 0.750000µs | 0.765400µs | 0.760274µs | 0.800000µs | 0.011868µs | 1.55%  | +84.14% |
	+-----------+-------------------------+--------+--------+--------+-----+------------+------------+------------+------------+------------+------------+--------+---------+

  