### PR TITLE
Performance enhancements for has(), setService(), setFactory(), setShared(), setAlias(), setInvokableClass() and configure()

### DIFF
--- a/benchmarks/HasBench.php
+++ b/benchmarks/HasBench.php
@@ -45,14 +45,6 @@ class HasBench
                 BenchAsset\AbstractFactoryFoo::class
             ]
         ]);
-
-        // forcing initialization of all the services
-        $this->sm->get('factory1');
-        $this->sm->get('invokable1');
-        $this->sm->get('service1');
-        $this->sm->get('alias1');
-        $this->sm->get('recursiveAlias1');
-        $this->sm->get('recursiveAlias2');
     }
 
     public function benchHasFactory1()

--- a/benchmarks/SetNewServicesBench.php
+++ b/benchmarks/SetNewServicesBench.php
@@ -56,6 +56,14 @@ class SetNewServicesBench
         $this->sm = new ServiceManager($config);
     }
 
+    public function benchSetService()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+
+        $sm->setService('service2', new \stdClass());
+    }
+
     public function benchSetFactory()
     {
         // @todo @link https://github.com/phpbench/phpbench/issues/304

--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -121,6 +121,15 @@ abstract class AbstractPluginManager extends ServiceManager implements PluginMan
     }
 
     /**
+     * Override setService for additional plugin validation.
+     */
+    public function setService($name, $service)
+    {
+        $this->validate($service);
+        parent::setService($name, $service);
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @param string $name Service name of plugin to retrieve.

--- a/src/Exception/ContainerModificationsNotAllowedException.php
+++ b/src/Exception/ContainerModificationsNotAllowedException.php
@@ -14,4 +14,14 @@ use DomainException;
  */
 class ContainerModificationsNotAllowedException extends DomainException implements ExceptionInterface
 {
+
+    public function __construct($service)
+    {
+        parent::__construct(sprintf(
+            'The container does not allow to replace/update a service'
+            . ' with existing instances; the following '
+            . 'already exist in the container: %s',
+            $service
+        ));
+    }
 }

--- a/src/Exception/ContainerModificationsNotAllowedException.php
+++ b/src/Exception/ContainerModificationsNotAllowedException.php
@@ -14,10 +14,9 @@ use DomainException;
  */
 class ContainerModificationsNotAllowedException extends DomainException implements ExceptionInterface
 {
-
-    public function __construct($service)
+    public static function fromExistingService($service)
     {
-        parent::__construct(sprintf(
+        return new self(sprintf(
             'The container does not allow to replace/update a service'
             . ' with existing instances; the following '
             . 'already exist in the container: %s',

--- a/src/Exception/CyclicAliasException.php
+++ b/src/Exception/CyclicAliasException.php
@@ -20,7 +20,7 @@ use function sprintf;
 class CyclicAliasException extends InvalidArgumentException
 {
     /**
-     * @param string   conflicting alias key
+     * @param string   $alias conflicting alias key
      * @param string[] $aliases map of referenced services, indexed by alias name (string)
      *
      * @return self

--- a/src/Exception/CyclicAliasException.php
+++ b/src/Exception/CyclicAliasException.php
@@ -7,11 +7,18 @@
 
 namespace Zend\ServiceManager\Exception;
 
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_values;
+use function implode;
+use function reset;
+use function serialize;
+use function sort;
 use function sprintf;
 
 class CyclicAliasException extends InvalidArgumentException
 {
-    public static $cycle;
     /**
      * @param string   conflicting alias key
      * @param string[] $aliases map of referenced services, indexed by alias name (string)
@@ -28,16 +35,135 @@ class CyclicAliasException extends InvalidArgumentException
         }
         $cycle .= ' -> ' . $alias . "\n";
 
-        // for testing
-        self::$cycle = $cycle;
         return new self(sprintf(
             "A cycle was detected within the aliases defintions:\n%s",
             $cycle
         ));
     }
 
-    public function getCycle()
+    /**
+     * @param string[] $aliases map of referenced services, indexed by alias name (string)
+     *
+     * @return self
+     */
+    public static function fromAliasesMap(array $aliases)
     {
-        return self::$cycle;
+        $detectedCycles = array_filter(array_map(
+            function ($alias) use ($aliases) {
+                return self::getCycleFor($aliases, $alias);
+            },
+            array_keys($aliases)
+        ));
+
+        if (! $detectedCycles) {
+            return new self(sprintf(
+                "A cycle was detected within the following aliases map:\n\n%s",
+                self::printReferencesMap($aliases)
+            ));
+        }
+
+        return new self(sprintf(
+            "Cycles were detected within the provided aliases:\n\n%s\n\n"
+            . "The cycle was detected in the following alias map:\n\n%s",
+            self::printCycles(self::deDuplicateDetectedCycles($detectedCycles)),
+            self::printReferencesMap($aliases)
+        ));
+    }
+
+    /**
+     * Retrieves the cycle detected for the given $alias, or `null` if no cycle was detected
+     *
+     * @param string[] $aliases
+     * @param string   $alias
+     *
+     * @return array|null
+     */
+    private static function getCycleFor(array $aliases, $alias)
+    {
+        $cycleCandidate = [];
+        $targetName     = $alias;
+
+        while (isset($aliases[$targetName])) {
+            if (isset($cycleCandidate[$targetName])) {
+                return $cycleCandidate;
+            }
+
+            $cycleCandidate[$targetName] = true;
+
+            $targetName = $aliases[$targetName];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string[] $aliases
+     *
+     * @return string
+     */
+    private static function printReferencesMap(array $aliases)
+    {
+        $map = [];
+
+        foreach ($aliases as $alias => $reference) {
+            $map[] = '"' . $alias . '" => "' . $reference . '"';
+        }
+
+        return "[\n" . implode("\n", $map) . "\n]";
+    }
+
+    /**
+     * @param string[][] $detectedCycles
+     *
+     * @return string
+     */
+    private static function printCycles(array $detectedCycles)
+    {
+        return "[\n" . implode("\n", array_map([__CLASS__, 'printCycle'], $detectedCycles)) . "\n]";
+    }
+
+    /**
+     * @param string[] $detectedCycle
+     *
+     * @return string
+     */
+    private static function printCycle(array $detectedCycle)
+    {
+        $fullCycle   = array_keys($detectedCycle);
+        $fullCycle[] = reset($fullCycle);
+
+        return implode(
+            ' => ',
+            array_map(
+                function ($cycle) {
+                    return '"' . $cycle . '"';
+                },
+                $fullCycle
+            )
+        );
+    }
+
+    /**
+     * @param bool[][] $detectedCycles
+     *
+     * @return bool[][] de-duplicated
+     */
+    private static function deDuplicateDetectedCycles(array $detectedCycles)
+    {
+        $detectedCyclesByHash = [];
+
+        foreach ($detectedCycles as $detectedCycle) {
+            $cycleAliases = array_keys($detectedCycle);
+
+            sort($cycleAliases);
+
+            $hash = serialize(array_values($cycleAliases));
+
+            $detectedCyclesByHash[$hash] = isset($detectedCyclesByHash[$hash])
+                ? $detectedCyclesByHash[$hash]
+                : $detectedCycle;
+        }
+
+        return array_values($detectedCyclesByHash);
     }
 }

--- a/src/Exception/CyclicAliasException.php
+++ b/src/Exception/CyclicAliasException.php
@@ -7,141 +7,28 @@
 
 namespace Zend\ServiceManager\Exception;
 
-use function array_filter;
-use function array_keys;
-use function array_map;
-use function array_values;
-use function implode;
-use function reset;
-use function serialize;
-use function sort;
 use function sprintf;
 
 class CyclicAliasException extends InvalidArgumentException
 {
     /**
+     * @param string   conflicting alias key
      * @param string[] $aliases map of referenced services, indexed by alias name (string)
      *
      * @return self
      */
-    public static function fromAliasesMap(array $aliases)
+    public static function fromCyclicAlias($alias, $aliases)
     {
-        $detectedCycles = array_filter(array_map(
-            function ($alias) use ($aliases) {
-                return self::getCycleFor($aliases, $alias);
-            },
-            array_keys($aliases)
-        ));
-
-        if (! $detectedCycles) {
-            return new self(sprintf(
-                "A cycle was detected within the following aliases map:\n\n%s",
-                self::printReferencesMap($aliases)
-            ));
+        $msg = $alias;
+        $cursor = $alias;
+        while($aliases[$cursor] !== $alias) {
+            $cursor = $aliases[$cursor];
+            $msg .= ' -> '. $cursor;
         }
-
+        $msg .= ' -> ' . $alias . PHP_EOL;
         return new self(sprintf(
-            "Cycles were detected within the provided aliases:\n\n%s\n\n"
-            . "The cycle was detected in the following alias map:\n\n%s",
-            self::printCycles(self::deDuplicateDetectedCycles($detectedCycles)),
-            self::printReferencesMap($aliases)
-        ));
-    }
-
-    /**
-     * Retrieves the cycle detected for the given $alias, or `null` if no cycle was detected
-     *
-     * @param string[] $aliases
-     * @param string   $alias
-     *
-     * @return array|null
-     */
-    private static function getCycleFor(array $aliases, $alias)
-    {
-        $cycleCandidate = [];
-        $targetName     = $alias;
-
-        while (isset($aliases[$targetName])) {
-            if (isset($cycleCandidate[$targetName])) {
-                return $cycleCandidate;
-            }
-
-            $cycleCandidate[$targetName] = true;
-
-            $targetName = $aliases[$targetName];
-        }
-
-        return null;
-    }
-
-    /**
-     * @param string[] $aliases
-     *
-     * @return string
-     */
-    private static function printReferencesMap(array $aliases)
-    {
-        $map = [];
-
-        foreach ($aliases as $alias => $reference) {
-            $map[] = '"' . $alias . '" => "' . $reference . '"';
-        }
-
-        return "[\n" . implode("\n", $map) . "\n]";
-    }
-
-    /**
-     * @param string[][] $detectedCycles
-     *
-     * @return string
-     */
-    private static function printCycles(array $detectedCycles)
-    {
-        return "[\n" . implode("\n", array_map([__CLASS__, 'printCycle'], $detectedCycles)) . "\n]";
-    }
-
-    /**
-     * @param string[] $detectedCycle
-     *
-     * @return string
-     */
-    private static function printCycle(array $detectedCycle)
-    {
-        $fullCycle   = array_keys($detectedCycle);
-        $fullCycle[] = reset($fullCycle);
-
-        return implode(
-            ' => ',
-            array_map(
-                function ($cycle) {
-                    return '"' . $cycle . '"';
-                },
-                $fullCycle
-            )
-        );
-    }
-
-    /**
-     * @param bool[][] $detectedCycles
-     *
-     * @return bool[][] de-duplicated
-     */
-    private static function deDuplicateDetectedCycles(array $detectedCycles)
-    {
-        $detectedCyclesByHash = [];
-
-        foreach ($detectedCycles as $detectedCycle) {
-            $cycleAliases = array_keys($detectedCycle);
-
-            sort($cycleAliases);
-
-            $hash = serialize(array_values($cycleAliases));
-
-            $detectedCyclesByHash[$hash] = isset($detectedCyclesByHash[$hash])
-                ? $detectedCyclesByHash[$hash]
-                : $detectedCycle;
-        }
-
-        return array_values($detectedCyclesByHash);
+            "A cycle was detected within the aliases defintions:\n%s",
+            $msg
+            ));
     }
 }

--- a/src/Exception/CyclicAliasException.php
+++ b/src/Exception/CyclicAliasException.php
@@ -11,6 +11,7 @@ use function sprintf;
 
 class CyclicAliasException extends InvalidArgumentException
 {
+    public static $cycle;
     /**
      * @param string   conflicting alias key
      * @param string[] $aliases map of referenced services, indexed by alias name (string)
@@ -19,16 +20,24 @@ class CyclicAliasException extends InvalidArgumentException
      */
     public static function fromCyclicAlias($alias, $aliases)
     {
-        $msg = $alias;
+        $cycle = $alias;
         $cursor = $alias;
-        while($aliases[$cursor] !== $alias) {
+        while (isset($aliases[$cursor]) && $aliases[$cursor] !== $alias) {
             $cursor = $aliases[$cursor];
-            $msg .= ' -> '. $cursor;
+            $cycle .= ' -> '. $cursor;
         }
-        $msg .= ' -> ' . $alias . PHP_EOL;
+        $cycle .= ' -> ' . $alias . "\n";
+
+        // for testing
+        self::$cycle = $cycle;
         return new self(sprintf(
             "A cycle was detected within the aliases defintions:\n%s",
-            $msg
-            ));
+            $cycle
+        ));
+    }
+
+    public function getCycle()
+    {
+        return self::$cycle;
     }
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -8,10 +8,32 @@
 namespace Zend\ServiceManager\Exception;
 
 use InvalidArgumentException as SplInvalidArgumentException;
+use Zend\ServiceManager\Initializer\InitializerInterface;
+use Zend\ServiceManager\AbstractFactoryInterface;
 
 /**
  * @inheritDoc
  */
 class InvalidArgumentException extends SplInvalidArgumentException implements ExceptionInterface
 {
+    public static function fromInvalidInitializer($initializer)
+    {
+        return new self(sprintf(
+            'An invalid initializer was registered. Expected a callable, or an instance of '
+            . '(or valid class name or function name resolving to) "%s", '
+            . 'but "%s" was received',
+            InitializerInterface::class,
+            (is_object($initializer) ? get_class($initializer) : gettype($initializer))
+        ));
+    }
+
+    public static function fromInvalidAbstractFactory($abstractFactory)
+    {
+        return new self(sprintf(
+            'An invalid abstract factory was registered. Expected an instance of or a '
+            . 'valid class name resolving to an implementation of "%s", but "%s" was received.',
+            AbstractFactoryInterface::class,
+            (is_object($abstractFactory) ? get_class($abstractFactory) : gettype($abstractFactory))
+        ));
+    }
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -23,7 +23,7 @@ class InvalidArgumentException extends SplInvalidArgumentException implements Ex
             . '(or valid class name or function name resolving to) "%s", '
             . 'but "%s" was received',
             InitializerInterface::class,
-            (is_object($initializer) ? get_class($initializer) : gettype($initializer))
+            is_object($initializer) ? get_class($initializer) : gettype($initializer)
         ));
     }
 
@@ -33,7 +33,7 @@ class InvalidArgumentException extends SplInvalidArgumentException implements Ex
             'An invalid abstract factory was registered. Expected an instance of or a '
             . 'valid class name resolving to an implementation of "%s", but "%s" was received.',
             AbstractFactoryInterface::class,
-            (is_object($abstractFactory) ? get_class($abstractFactory) : gettype($abstractFactory))
+            is_object($abstractFactory) ? get_class($abstractFactory) : gettype($abstractFactory)
         ));
     }
 }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -345,7 +345,6 @@ class ServiceManager implements ServiceLocatorInterface
             $factories = $this->createFactoriesForInvokables($config['invokables']);
 
             if (! empty($aliases)) {
-                // @todo: This is wrong! These aliases are 'resolved' already
                 $config['aliases'] = (isset($config['aliases']))
                     ? \array_merge($config['aliases'], $aliases)
                     : $aliases;
@@ -520,6 +519,7 @@ class ServiceManager implements ServiceLocatorInterface
      *
      * @param string[]|Initializer\InitializerInterface[]|callable[] $initializers
      *
+     * @return void
      */
     private function resolveInitializer($initializer)
     {
@@ -926,13 +926,6 @@ class ServiceManager implements ServiceLocatorInterface
 
     /**
      * Instantiate abstract factories for to avoid checks during service construction.
-     *
-     * @todo: To construct to avoid is not really an optimization, it's lazyness
-     * AbstractFactories are shared services. Make sure that has() is guarded against
-     * numerical parameters. Handle AbstractFactories as any other shared services.
-     *
-     * @todo: Implement a has() and get() logic which unifies the several arrays
-     * It is a desaster to isset(blah) several times on each request.
      *
      * @param string[]|Factory\AbstractFactoryInterface[] $abstractFactories
      *

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -413,7 +413,7 @@ class ServiceManager implements ServiceLocatorInterface
             $this->mapAliasToTarget($alias, $target);
             return;
         }
-        throw new ContainerModificationsNotAllowedException($alias);
+        throw ContainerModificationsNotAllowedException::fromExistingService($alias);
     }
 
     /**
@@ -429,7 +429,7 @@ class ServiceManager implements ServiceLocatorInterface
             $this->createAliasesAndFactoriesForInvokables([$name => $class ?? $name]);
             return;
         }
-        throw new ContainerModificationsNotAllowedException($name);
+        throw ContainerModificationsNotAllowedException::fromExistingService($name);
     }
 
     /**
@@ -445,7 +445,7 @@ class ServiceManager implements ServiceLocatorInterface
             $this->factories[$name] = $factory;
             return;
         }
-        throw new ContainerModificationsNotAllowedException($name);
+        throw ContainerModificationsNotAllowedException::fromExistingService($name);
     }
 
     /**
@@ -504,7 +504,7 @@ class ServiceManager implements ServiceLocatorInterface
             $this->services[$name] = $service;
             return;
         }
-        throw new ContainerModificationsNotAllowedException($name);
+        throw ContainerModificationsNotAllowedException::fromExistingService($name);
     }
 
     /**
@@ -519,7 +519,7 @@ class ServiceManager implements ServiceLocatorInterface
             $this->shared[$name] = (bool) $flag;
             return;
         }
-        throw new ContainerModificationsNotAllowedException($name);
+        throw ContainerModificationsNotAllowedException::fromExistingService($name);
     }
 
     /**
@@ -798,7 +798,7 @@ class ServiceManager implements ServiceLocatorInterface
                 if (! isset($this->services[$service]) || $this->allowOverride) {
                     continue;
                 }
-                throw new ContainerModificationsNotAllowedException($service);
+                throw ContainerModificationsNotAllowedException::fromExistingService($service);
             }
         }
 
@@ -807,7 +807,7 @@ class ServiceManager implements ServiceLocatorInterface
                 if (! isset($this->services[$service]) || $this->allowOverride) {
                     continue;
                 }
-                throw new ContainerModificationsNotAllowedException($service);
+                throw ContainerModificationsNotAllowedException::fromExistingService($service);
             }
         }
 
@@ -816,7 +816,7 @@ class ServiceManager implements ServiceLocatorInterface
                 if (! isset($this->services[$service]) || $this->allowOverride) {
                     continue;
                 }
-                throw new ContainerModificationsNotAllowedException($service);
+                throw ContainerModificationsNotAllowedException::fromExistingService($service);
             }
         }
 
@@ -825,7 +825,7 @@ class ServiceManager implements ServiceLocatorInterface
                 if (! isset($this->services[$service]) || $this->allowOverride) {
                     continue;
                 }
-                throw new ContainerModificationsNotAllowedException($service);
+                throw ContainerModificationsNotAllowedException::fromExistingService($service);
             }
         }
 
@@ -834,7 +834,7 @@ class ServiceManager implements ServiceLocatorInterface
                 if (! isset($this->services[$service]) || $this->allowOverride) {
                     continue;
                 }
-                throw new ContainerModificationsNotAllowedException($service);
+                throw ContainerModificationsNotAllowedException::fromExistingService($service);
             }
         }
 
@@ -843,7 +843,7 @@ class ServiceManager implements ServiceLocatorInterface
                 if (! isset($this->services[$service]) || $this->allowOverride) {
                     continue;
                 }
-                throw new ContainerModificationsNotAllowedException($service);
+                throw ContainerModificationsNotAllowedException::fromExistingService($service);
             }
         }
 
@@ -852,7 +852,7 @@ class ServiceManager implements ServiceLocatorInterface
                 if (! isset($this->services[$service]) || $this->allowOverride) {
                     continue;
                 }
-                throw new ContainerModificationsNotAllowedException($service);
+                throw ContainerModificationsNotAllowedException::fromExistingService($service);
             }
         }
     }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -21,18 +21,18 @@ use Zend\ServiceManager\Exception\InvalidArgumentException;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 
-use function \array_merge_recursive;
-use function \class_exists;
-use function \get_class;
-use function \gettype;
-use function \is_callable;
-use function \is_object;
-use function \is_string;
-use function \spl_autoload_register;
-use function \spl_object_hash;
-use function \sprintf;
-use function \trigger_error;
-use function \in_array;
+use function array_merge_recursive;
+use function class_exists;
+use function get_class;
+use function gettype;
+use function is_callable;
+use function is_object;
+use function is_string;
+use function spl_autoload_register;
+use function spl_object_hash;
+use function sprintf;
+use function trigger_error;
+use function in_array;
 
 /**
  * Service Manager.
@@ -526,8 +526,6 @@ class ServiceManager implements ServiceLocatorInterface
      * Instantiate initializers for to avoid checks during service construction.
      *
      * @param string[]|Initializer\InitializerInterface[]|callable[] $initializers
-     *
-     * @return void
      */
     private function resolveInitializers(array $initializers)
     {

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -420,7 +420,6 @@ class ServiceManager implements ServiceLocatorInterface
     {
         $this->validate($alias);
         $this->doSetAlias($alias, $target);
-
     }
 
     /**
@@ -963,8 +962,8 @@ class ServiceManager implements ServiceLocatorInterface
                     'to an implementation of %s',
                     $abstractFactory,
                     AbstractFactoryInterface::class
-                    )
-                );
+                )
+            );
         }
 
         // Otherwise, we have an invalid type.
@@ -974,7 +973,7 @@ class ServiceManager implements ServiceLocatorInterface
                 'but "%s" was received',
                 AbstractFactoryInterface::class,
                 (is_object($abstractFactory) ? get_class($abstractFactory) : gettype($abstractFactory))
-                )
-            );
+            )
+        );
     }
 }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -436,13 +436,10 @@ class ServiceManager implements ServiceLocatorInterface
     public function setAlias($alias, $target)
     {
         $this->validate($alias);
-
         $this->aliases[$alias] = $target;
 
-        if (isset($this->resolvedAliases[$target])) {
-            $target = $this->resolvedAliases[$target];
-        }
-        $this->resolvedAliases[$alias] = $target;
+        $this->resolvedAliases[$alias] =
+            isset($this->resolvedAliases[$target]) ? $this->resolvedAliases[$target] : $target;
         if (in_array($alias, $this->resolvedAliases)) {
             $r = array_intersect($this->resolvedAliases, [ $alias ]);
             foreach ($r as $name => $service) {

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -194,7 +194,7 @@ class ServiceManager implements ServiceLocatorInterface
 
         // We achieve better performance if we can let all alias
         // considerations out
-        if (empty($this->aliases)) {
+        if (! $this->aliases) {
             $object = $this->doCreate($name);
 
             // Cache the object for later, if it is supposed to be shared.
@@ -364,7 +364,7 @@ class ServiceManager implements ServiceLocatorInterface
             $this->shared = $config['shared'] + $this->shared;
         }
 
-        if (isset($config['aliases'])) {
+        if (! empty($config['aliases'])) {
             $this->aliases = $config['aliases'] + $this->aliases;
             $this->mapAliasesToTargets();
         } elseif (! $this->configured && ! empty($this->aliases)) {

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -267,7 +267,16 @@ class ServiceManager implements ServiceLocatorInterface
 
         // Finally check aliases
         $resolvedName = $this->aliases[$name];
-        return isset($this->services[$resolvedName]) || isset($this->factories[$resolvedName]);
+        if (isset($this->services[$resolvedName]) || isset($this->factories[$resolvedName])) {
+            return true;
+        }
+
+        // Check abstract factories on $resolvedName also
+        foreach ($this->abstractFactories as $abstractFactory) {
+            if ($abstractFactory->canCreate($this->creationContext, $resolvedName)) {
+                return true;
+            }
+        }
     }
 
     /**

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -435,7 +435,18 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setAlias($alias, $target)
     {
-        $this->configure(['aliases' => [$alias => $target]]);
+        $this->validate($alias);
+        if(isset($this->resolvedAliases[$target])) {
+            $target = $this->resolvedAliases[$target];
+        }
+        $this->resolvedAliases[$alias] = $target;
+        if (in_array($alias, $this->resolvedAliases)) {
+            $r = array_intersect($this->resolvedAliases, [ $alias ]);
+            foreach($r as $name => $service) {
+                print($name." ".$service. " ".$target."\n");
+                $this->resolvedAliases[$name] = $target;
+            }
+        }
     }
 
     /**

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -923,13 +923,13 @@ class ServiceManager implements ServiceLocatorInterface
 
     /**
      * Instantiate abstract factories for to avoid checks during service construction.
-     * 
+     *
      * @todo: To construct to avoid is not really an optimization, it's lazyness
      * AbstractFactories are shared services. Make sure that has() is guarded against
      * numerical parameters. Handle AbstractFactories as any other shared services.
-     * 
+     *
      * @todo: Implement a has() and get() logic which unifies the several arrays
-     * It is not necessary to isset(blah) several times on a request.
+     * It is a desaster to isset(blah) several times on each request.
      *
      * @param string[]|Factory\AbstractFactoryInterface[] $abstractFactories
      *

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -859,6 +859,12 @@ class ServiceManager implements ServiceLocatorInterface
 
     /**
      * Assuming that the alias name is valid (see above) resolve/add it.
+     * 
+     * This is done differently from bulk mapping aliases for performance reasons, as the
+     * algorithms for mapping a single item efficiently are different from those of mapping
+     * many.
+     *
+     * @see mapAliasesToTargets() below
      *
      * @param string $alias
      * @param string $target
@@ -888,13 +894,12 @@ class ServiceManager implements ServiceLocatorInterface
     /**
      * Assuming that all provided alias keys are valid resolve them.
      *
-     * This as an adaptation of Tarjan's strongly connected components
-     * algorithm. We detect cycles as well reduce the graph so that
-     * each alias key gets associated with the resolved service.
      * This function maps $this->aliases in place.
      *
      * This algorithm is fast for mass updates through configure().
      * It is not appropriate if just a single alias is added.
+     * 
+     * @see mapAliasToTarget above  
      *
      */
     private function mapAliasesToTargets()
@@ -906,7 +911,6 @@ class ServiceManager implements ServiceLocatorInterface
             }
             $tCursor = $this->aliases[$alias];
             $aCursor = $alias;
-            $stack = [];
             while (isset($this->aliases[$tCursor])) {
                 $tagged[$aCursor] = true;
                 $this->aliases[$aCursor] = $this->aliases[$tCursor];

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -21,19 +21,20 @@ use Zend\ServiceManager\Exception\InvalidArgumentException;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 
-use function array_keys;
-use function array_merge;
-use function array_merge_recursive;
-use function class_exists;
-use function get_class;
-use function gettype;
-use function is_callable;
-use function is_object;
-use function is_string;
-use function spl_autoload_register;
-use function spl_object_hash;
-use function sprintf;
-use function trigger_error;
+use function \array_keys;
+use function \array_merge;
+use function \array_merge_recursive;
+use function \class_exists;
+use function \get_class;
+use function \gettype;
+use function \is_callable;
+use function \is_object;
+use function \is_string;
+use function \spl_autoload_register;
+use function \spl_object_hash;
+use function \sprintf;
+use function \trigger_error;
+use function \in_array;
 
 /**
  * Service Manager.
@@ -104,11 +105,6 @@ class ServiceManager implements ServiceLocatorInterface
      * @var null|Proxy\LazyServiceFactory
      */
     private $lazyServicesDelegator;
-
-//     /**
-//      * @var string[]
-//      */
-//     private $resolvedAliases = [];
 
     /**
      * A list of already loaded services (this act as a local cache)
@@ -204,7 +200,7 @@ class ServiceManager implements ServiceLocatorInterface
             $object = $this->doCreate($name);
 
             // Cache the object for later, if it is supposed to be shared.
-            if (($sharedService)) {
+            if ($sharedService) {
                 $this->services[$name] = $object;
             }
             return $object;
@@ -229,8 +225,8 @@ class ServiceManager implements ServiceLocatorInterface
         if (($sharedService)) {
             $this->services[$resolvedName] = $object;
         }
+
         // Also do so for aliases, this allows sharing based on service name used.
-        // $serviceAvailable is true if and only if we have an alias
         if ($sharedAlias) {
             $this->services[$name] = $object;
         }
@@ -351,12 +347,12 @@ class ServiceManager implements ServiceLocatorInterface
 
             if (! empty($aliases)) {
                 $config['aliases'] = (isset($config['aliases']))
-                    ? \array_merge($config['aliases'], $aliases)
+                    ? array_merge($config['aliases'], $aliases)
                     : $aliases;
             }
 
             $config['factories'] = (isset($config['factories']))
-                ? \array_merge($config['factories'], $factories)
+                ? array_merge($config['factories'], $factories)
                 : $factories;
         }
 
@@ -365,7 +361,7 @@ class ServiceManager implements ServiceLocatorInterface
         }
 
         if (isset($config['delegators'])) {
-            $this->delegators = \array_merge_recursive($this->delegators, $config['delegators']);
+            $this->delegators = array_merge_recursive($this->delegators, $config['delegators']);
         }
 
         if (isset($config['shared'])) {
@@ -380,7 +376,7 @@ class ServiceManager implements ServiceLocatorInterface
         }
         if (! empty($aliases)) {
             foreach ($aliases as $alias => $target) {
-                $this->doSetAlias($alias, $target);
+                $this->mapAliasToTarget($alias, $target);
             }
         }
 
@@ -391,7 +387,7 @@ class ServiceManager implements ServiceLocatorInterface
         // If lazy service configuration was provided, reset the lazy services
         // delegator factory.
         if (isset($config['lazy_services']) && ! empty($config['lazy_services'])) {
-            $this->lazyServices          = \array_merge_recursive($this->lazyServices, $config['lazy_services']);
+            $this->lazyServices          = array_merge_recursive($this->lazyServices, $config['lazy_services']);
             $this->lazyServicesDelegator = null;
         }
 
@@ -401,7 +397,7 @@ class ServiceManager implements ServiceLocatorInterface
             $abstractFactories = $config['abstract_factories'];
             // $key not needed, but foreach faster
             foreach ($abstractFactories as $key => $abstractFactory) {
-                $this->doAddAbstractFactory($abstractFactory);
+                $this->resolveAbstractFactoryInstance($abstractFactory);
             }
         }
 
@@ -423,7 +419,7 @@ class ServiceManager implements ServiceLocatorInterface
     public function setAlias($alias, $target)
     {
         $this->validateServiceName($alias);
-        $this->doSetAlias($alias, $target);
+        $this->mapAliasToTarget($alias, $target);
     }
 
     /**
@@ -470,7 +466,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function addAbstractFactory($factory)
     {
-        $this->doAddAbstractFactory($factory);
+        $this->resolveAbstractFactoryInstance($factory);
     }
 
     /**
@@ -528,39 +524,35 @@ class ServiceManager implements ServiceLocatorInterface
      */
     private function resolveInitializer($initializer)
     {
-        if (\is_string($initializer) && \class_exists($initializer)) {
+        if (is_string($initializer) && class_exists($initializer)) {
             $initializer = new $initializer();
         }
 
-        if (\is_callable($initializer)) {
+        if (is_callable($initializer)) {
             $this->initializers[] = $initializer;
             return;
         }
 
         // Error condition; let's find out why.
 
-        if (\is_string($initializer)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'An invalid initializer was registered; resolved to class or function "%s" ' .
-                    'which does not exist; please provide a valid function name or class ' .
-                    'name resolving to an implementation of %s',
-                    $initializer,
-                    Initializer\InitializerInterface::class
-                )
-            );
+        if (is_string($initializer)) {
+            throw new InvalidArgumentException(sprintf(
+                'An invalid initializer was registered; resolved to class or function "%s" ' 
+                . 'which does not exist; please provide a valid function name or class ' 
+                . 'name resolving to an implementation of %s',
+                $initializer,
+                Initializer\InitializerInterface::class
+            ));
         }
 
         // Otherwise, we have an invalid type.
-        throw new InvalidArgumentException(
-            sprintf(
-                'An invalid initializer was registered. Expected a callable, or an instance of ' .
-                '(or string class name resolving to) "%s", ' .
-                'but "%s" was received',
-                Initializer\InitializerInterface::class,
-                (is_object($initializer) ? get_class($initializer) : gettype($initializer))
-            )
-        );
+        throw new InvalidArgumentException(sprintf(
+            'An invalid initializer was registered. Expected a callable, or an instance of ' 
+            . '(or string class name resolving to) "%s", ' 
+            . 'but "%s" was received',
+            Initializer\InitializerInterface::class,
+            (is_object($initializer) ? get_class($initializer) : gettype($initializer))
+        ));
     }
 
     /**
@@ -589,12 +581,12 @@ class ServiceManager implements ServiceLocatorInterface
         $factory = $this->factories[$name] ?? null;
 
         $lazyLoaded = false;
-        if (\is_string($factory) && \class_exists($factory)) {
+        if (is_string($factory) && class_exists($factory)) {
             $factory = new $factory();
             $lazyLoaded = true;
         }
 
-        if (\is_callable($factory)) {
+        if (is_callable($factory)) {
             if ($lazyLoaded) {
                 $this->factories[$name] = $factory;
             }
@@ -635,13 +627,13 @@ class ServiceManager implements ServiceLocatorInterface
                 $delegatorFactory = $this->createLazyServiceDelegatorFactory();
             }
 
-            if (\is_string($delegatorFactory) && \class_exists($delegatorFactory)) {
+            if (is_string($delegatorFactory) && class_exists($delegatorFactory)) {
                 $delegatorFactory = new $delegatorFactory();
             }
 
-            if (! \is_callable($delegatorFactory)) {
-                if (\is_string($delegatorFactory)) {
-                    throw new ServiceNotCreatedException(\sprintf(
+            if (! is_callable($delegatorFactory)) {
+                if (is_string($delegatorFactory)) {
+                    throw new ServiceNotCreatedException(sprintf(
                         'An invalid delegator factory was registered; resolved to class or function "%s" '
                         . 'which does not exist; please provide a valid function name or class name resolving '
                         . 'to an implementation of %s',
@@ -650,9 +642,9 @@ class ServiceManager implements ServiceLocatorInterface
                     ));
                 }
 
-                throw new ServiceNotCreatedException(\sprintf(
+                throw new ServiceNotCreatedException(sprintf(
                     'A non-callable delegator, "%s", was provided; expected a callable or instance of "%s"',
-                    \is_object($delegatorFactory) ? \get_class($delegatorFactory) : \gettype($delegatorFactory),
+                    is_object($delegatorFactory) ? get_class($delegatorFactory) : gettype($delegatorFactory),
                     DelegatorFactoryInterface::class
                 ));
             }
@@ -745,7 +737,7 @@ class ServiceManager implements ServiceLocatorInterface
             ));
         }
 
-        \spl_autoload_register($factoryConfig->getProxyAutoloader());
+        spl_autoload_register($factoryConfig->getProxyAutoloader());
 
         $this->lazyServicesDelegator = new Proxy\LazyServiceFactory(
             new LazyLoadingValueHolderFactory($factoryConfig),
@@ -818,15 +810,10 @@ class ServiceManager implements ServiceLocatorInterface
         // Important: Next three lines must kept equal to the three
         // lines of validateServiceNameArray (see below) which are marked as code
         // duplicate!
-        if (! isset($this->services[$service]) ?: $this->allowOverride) {
+        if (! isset($this->services[$service]) || $this->allowOverride) {
             return;
         }
-        throw new ContainerModificationsNotAllowedException(sprintf(
-            'The container does not allow to replace/update a service'
-            . ' with existing instances; the following '
-            . 'already exist in the container: %s',
-            $service
-        ));
+        throw new ContainerModificationsNotAllowedException($service);
     }
 
     /**
@@ -845,8 +832,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     private function validateServiceNameArray(array $services)
     {
-        $keys = \array_keys($services);
-        foreach ($keys as $service) {
+        foreach (array_keys($services) as $service) {
             // This is a code duplication from validateServiceName (see above).
             // validateServiceName is almost a one liner, so we reproduce it
             // here for the sake of performance of aggregated service
@@ -858,12 +844,7 @@ class ServiceManager implements ServiceLocatorInterface
             if (! isset($this->services[$service]) ?: $this->allowOverride) {
                 return;
             }
-            throw new ContainerModificationsNotAllowedException(sprintf(
-                'The container does not allow to replace/update a service'
-                . ' with existing instances; the following '
-                . 'already exist in the container: %s',
-                $service
-            ));
+            throw new ContainerModificationsNotAllowedException($service);
         }
     }
 
@@ -906,12 +887,11 @@ class ServiceManager implements ServiceLocatorInterface
      * @param string $alias
      * @param string $target
      */
-    private function doSetAlias($alias, $target)
+    private function mapAliasToTarget($alias, $target)
     {
         // $target is either an alias or something else
         // if it is an alias, resolve it
-        $this->aliases[$alias] =
-            isset($this->aliases[$target]) ? $this->aliases[$target] : $target;
+        $this->aliases[$alias] = $this->aliases[$target] ?? $target;
 
         // a self-referencing alias indicates a cycle
         if ($alias === $this->aliases[$alias]) {
@@ -920,7 +900,7 @@ class ServiceManager implements ServiceLocatorInterface
 
         // finally we have to check if existing incomplete alias definitions
         // exist which can get resolved by the new alias
-        if (in_array($alias, $this->aliases)) {
+        if (in_array($alias, $this->aliases, true)) {
             $r = array_intersect($this->aliases, [ $alias ]);
             // found some, resolve them
             foreach ($r as $name => $service) {
@@ -930,16 +910,16 @@ class ServiceManager implements ServiceLocatorInterface
     }
 
     /**
-     * Instantiate abstract factories for to avoid checks during service construction.
+     * Instantiate abstract factories in order to avoid checks during service construction.
      *
      * @param string[]|Factory\AbstractFactoryInterface[] $abstractFactories
      *
      * @return void
      */
-    private function doAddAbstractFactory($abstractFactory)
+    private function resolveAbstractFactoryInstance($abstractFactory)
     {
-        if (\is_string($abstractFactory) && \class_exists($abstractFactory)) {
-            //Cached string
+        if (is_string($abstractFactory) && class_exists($abstractFactory)) {
+            // cached string
             if (! isset($this->cachedAbstractFactories[$abstractFactory])) {
                 $this->cachedAbstractFactories[$abstractFactory] = new $abstractFactory();
             }
@@ -948,7 +928,7 @@ class ServiceManager implements ServiceLocatorInterface
         }
 
         if ($abstractFactory instanceof Factory\AbstractFactoryInterface) {
-            $abstractFactoryObjHash = \spl_object_hash($abstractFactory);
+            $abstractFactoryObjHash = spl_object_hash($abstractFactory);
             $this->abstractFactories[$abstractFactoryObjHash] = $abstractFactory;
             return;
         }
@@ -956,26 +936,22 @@ class ServiceManager implements ServiceLocatorInterface
         // Error condition; let's find out why.
 
         // If we still have a string, we have a class name that does not resolve
-        if (\is_string($abstractFactory)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'An invalid abstract factory was registered; resolved to class "%s" ' .
-                    'which does not exist; please provide a valid class name resolving ' .
-                    'to an implementation of %s',
-                    $abstractFactory,
-                    AbstractFactoryInterface::class
-                )
-            );
+        if (is_string($abstractFactory)) {
+            throw new InvalidArgumentException(sprintf(
+                'An invalid abstract factory was registered; resolved to class "%s" ' 
+                . 'which does not exist; please provide a valid class name resolving ' 
+                . 'to an implementation of %s',
+                $abstractFactory,
+                AbstractFactoryInterface::class
+            ));
         }
 
         // Otherwise, we have an invalid type.
-        throw new InvalidArgumentException(
-            sprintf(
-                'An invalid abstract factory was registered. Expected an instance of "%s", ' .
-                'but "%s" was received',
-                AbstractFactoryInterface::class,
-                (is_object($abstractFactory) ? get_class($abstractFactory) : gettype($abstractFactory))
-            )
-        );
+        throw new InvalidArgumentException(sprintf(
+            'An invalid abstract factory was registered. Expected an instance of "%s", ' 
+            . 'but "%s" was received',
+            AbstractFactoryInterface::class,
+            (is_object($abstractFactory) ? get_class($abstractFactory) : gettype($abstractFactory))
+        ));
     }
 }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -339,7 +339,7 @@ class ServiceManager implements ServiceLocatorInterface
     {
         // This is a bulk update/initial configuration
         // So we check all definitions
-        $this->validateConfig($config);
+        $this->validateServiceNameConfig($config);
 
         if (isset($config['services'])) {
             $this->services = $config['services'] + $this->services;
@@ -422,7 +422,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setAlias($alias, $target)
     {
-        $this->validate($alias);
+        $this->validateServiceName($alias);
         $this->doSetAlias($alias, $target);
     }
 
@@ -447,7 +447,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setFactory($name, $factory)
     {
-        $this->validate($name);
+        $this->validateServiceName($name);
         $this->factories[$name] = $factory;
     }
 
@@ -503,7 +503,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setService($name, $service)
     {
-        $this->validate($name);
+        $this->validateServiceName($name);
         $this->services[$name] = $service;
     }
 
@@ -515,7 +515,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setShared($name, $flag)
     {
-        $this->validate($name);
+        $this->validateServiceName($name);
         $this->shared[$name] = (bool) $flag;
     }
 
@@ -813,10 +813,10 @@ class ServiceManager implements ServiceLocatorInterface
      * @throws ContainerModificationsNotAllowedException if the
      *     provided service name is invalid.
      */
-    private function validate($service)
+    private function validateServiceName($service)
     {
         // Important: Next three lines must kept equal to the three
-        // lines of validateArray (see below) which are marked as code
+        // lines of validateServiceNameArray (see below) which are marked as code
         // duplicate!
         if (! isset($this->services[$service]) ?: $this->allowOverride) {
             return;
@@ -843,18 +843,18 @@ class ServiceManager implements ServiceLocatorInterface
      * @throws ContainerModificationsNotAllowedException if any
      *     array keys is invalid.
      */
-    private function validateArray(array $services)
+    private function validateServiceNameArray(array $services)
     {
         $keys = \array_keys($services);
         foreach ($keys as $service) {
-            // This is a code duplication from validate (see above).
-            // validate is almost a one liner, so we reproduce it
+            // This is a code duplication from validateServiceName (see above).
+            // validateServiceName is almost a one liner, so we reproduce it
             // here for the sake of performance of aggregated service
             // manager configurations (we save the overhead the function
             // call would produce)
             //
             // Important: Next three lines MUST kept equal to the first
-            // three lines of validate!
+            // three lines of validateServiceName!
             if (! isset($this->services[$service]) ?: $this->allowOverride) {
                 return;
             }
@@ -881,7 +881,7 @@ class ServiceManager implements ServiceLocatorInterface
      * @throws ContainerModificationsNotAllowedException if any
      *     service key is invalid.
      */
-    private function validateConfig(array $config)
+    private function validateServiceNameConfig(array $config)
     {
         if ($this->allowOverride || ! $this->configured) {
             return;
@@ -891,12 +891,12 @@ class ServiceManager implements ServiceLocatorInterface
 
         foreach ($sections as $section) {
             if (isset($config[$section])) {
-                $this->validateArray($config[$section]);
+                $this->validateServiceNameArray($config[$section]);
             }
         }
 
         if (isset($config['lazy_services']['class_map'])) {
-            $this->validateArray($config['lazy_services']['class_map']);
+            $this->validateServiceNameArray($config['lazy_services']['class_map']);
         }
     }
 

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -520,7 +520,6 @@ class ServiceManager implements ServiceLocatorInterface
      *
      * @param string[]|Initializer\InitializerInterface[]|callable[] $initializers
      *
-     * @return void
      */
     private function resolveInitializer($initializer)
     {
@@ -904,15 +903,21 @@ class ServiceManager implements ServiceLocatorInterface
      */
     private function doSetAlias($alias, $target)
     {
+        // $target is either an alias or something else
+        // if it is an alias, resolve it
         $this->aliases[$alias] =
             isset($this->aliases[$target]) ? $this->aliases[$target] : $target;
 
+        // a self-referencing alias indicates a cycle
         if ($alias === $this->aliases[$alias]) {
             throw CyclicAliasException::fromCyclicAlias($alias, $this->aliases);
         }
 
+        // finally we have to check if existing incomplete alias definitions
+        // exist which can get resolved by the new alias
         if (in_array($alias, $this->aliases)) {
             $r = array_intersect($this->aliases, [ $alias ]);
+            // found some, resolve them
             foreach ($r as $name => $service) {
                 $this->aliases[$name] = $target;
             }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -859,7 +859,7 @@ class ServiceManager implements ServiceLocatorInterface
 
     /**
      * Assuming that the alias name is valid (see above) resolve/add it.
-     * 
+     *
      * This is done differently from bulk mapping aliases for performance reasons, as the
      * algorithms for mapping a single item efficiently are different from those of mapping
      * many.
@@ -898,8 +898,8 @@ class ServiceManager implements ServiceLocatorInterface
      *
      * This algorithm is fast for mass updates through configure().
      * It is not appropriate if just a single alias is added.
-     * 
-     * @see mapAliasToTarget above  
+     *
+     * @see mapAliasToTarget above
      *
      */
     private function mapAliasesToTargets()

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -529,50 +529,19 @@ class ServiceManager implements ServiceLocatorInterface
      *
      * @return void
      */
-    private function resolveInitializer($initializer)
-    {
-        if (is_string($initializer) && class_exists($initializer)) {
-            $initializer = new $initializer();
-        }
-
-        if (is_callable($initializer)) {
-            $this->initializers[] = $initializer;
-            return;
-        }
-
-        // Error condition; let's find out why.
-
-        if (is_string($initializer)) {
-            throw new InvalidArgumentException(sprintf(
-                'An invalid initializer was registered; resolved to class or function "%s" '
-                . 'which does not exist; please provide a valid function name or class '
-                . 'name resolving to an implementation of %s',
-                $initializer,
-                Initializer\InitializerInterface::class
-            ));
-        }
-
-        // Otherwise, we have an invalid type.
-        throw new InvalidArgumentException(sprintf(
-            'An invalid initializer was registered. Expected a callable, or an instance of '
-            . '(or string class name resolving to) "%s", '
-            . 'but "%s" was received',
-            Initializer\InitializerInterface::class,
-            (is_object($initializer) ? get_class($initializer) : gettype($initializer))
-        ));
-    }
-
-    /**
-     * Instantiate initializers for to avoid checks during service construction.
-     *
-     * @param string[]|Initializer\InitializerInterface[]|callable[] $initializers
-     *
-     * @return void
-     */
     private function resolveInitializers(array $initializers)
     {
         foreach ($initializers as $initializer) {
-            $this->resolveInitializer($initializer);
+            if (is_string($initializer) && class_exists($initializer)) {
+                $initializer = new $initializer();
+            }
+
+            if (is_callable($initializer)) {
+                $this->initializers[] = $initializer;
+                return;
+            }
+
+            throw InvalidArgumentException::fromInvalidInitializer($initializer);
         }
     }
 
@@ -947,25 +916,6 @@ class ServiceManager implements ServiceLocatorInterface
             return;
         }
 
-        // Error condition; let's find out why.
-
-        // If we still have a string, we have a class name that does not resolve
-        if (is_string($abstractFactory)) {
-            throw new InvalidArgumentException(sprintf(
-                'An invalid abstract factory was registered; resolved to class "%s" '
-                . 'which does not exist; please provide a valid class name resolving '
-                . 'to an implementation of %s',
-                $abstractFactory,
-                AbstractFactoryInterface::class
-            ));
-        }
-
-        // Otherwise, we have an invalid type.
-        throw new InvalidArgumentException(sprintf(
-            'An invalid abstract factory was registered. Expected an instance of "%s", '
-            . 'but "%s" was received',
-            AbstractFactoryInterface::class,
-            (is_object($abstractFactory) ? get_class($abstractFactory) : gettype($abstractFactory))
-        ));
+        throw InvalidArgumentException::fromInvalidAbstractFactory($abstractFactory);
     }
 }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -443,7 +443,6 @@ class ServiceManager implements ServiceLocatorInterface
         if (in_array($alias, $this->resolvedAliases)) {
             $r = array_intersect($this->resolvedAliases, [ $alias ]);
             foreach($r as $name => $service) {
-                print($name." ".$service. " ".$target."\n");
                 $this->resolvedAliases[$name] = $target;
             }
         }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -436,13 +436,13 @@ class ServiceManager implements ServiceLocatorInterface
     public function setAlias($alias, $target)
     {
         $this->validate($alias);
-        if(isset($this->resolvedAliases[$target])) {
+        if (isset($this->resolvedAliases[$target])) {
             $target = $this->resolvedAliases[$target];
         }
         $this->resolvedAliases[$alias] = $target;
         if (in_array($alias, $this->resolvedAliases)) {
             $r = array_intersect($this->resolvedAliases, [ $alias ]);
-            foreach($r as $name => $service) {
+            foreach ($r as $name => $service) {
                 $this->resolvedAliases[$name] = $target;
             }
         }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -253,21 +253,26 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function has($name)
     {
-        $name  = $this->aliases[$name] ?? $name;
-        $found = isset($this->services[$name]) || isset($this->factories[$name]);
-
-        if ($found) {
-            return $found;
+        // Check services and factories first to speedup the most common requests
+        if (isset($this->services[$name]) || isset($this->factories[$name])) {
+            return true;
         }
 
-        // Check abstract factories
+        // Check abstract factories next
         foreach ($this->abstractFactories as $abstractFactory) {
             if ($abstractFactory->canCreate($this->creationContext, $name)) {
                 return true;
             }
         }
 
-        return false;
+        // If $name is no alias, we are done
+        if (! isset($this->aliases[$name])) {
+            return false;
+        }
+
+        // Finally check aliases
+        $resolvedName = $this->aliases[$name];
+        return isset($this->services[$resolvedName]) || isset($this->factories[$resolvedName]);
     }
 
     /**

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -436,6 +436,9 @@ class ServiceManager implements ServiceLocatorInterface
     public function setAlias($alias, $target)
     {
         $this->validate($alias);
+
+        $this->aliases[$alias] = $target;
+
         if (isset($this->resolvedAliases[$target])) {
             $target = $this->resolvedAliases[$target];
         }

--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -545,7 +545,7 @@ trait CommonServiceLocatorBehaviorsTrait
     public function invalidInitializers()
     {
         $factories = $this->invalidFactories();
-        $factories['non-class-string'] = ['non-callable-string', 'valid function name or class name'];
+        $factories['non-class-string'] = ['non-callable-string', 'valid class name or function name'];
         return $factories;
     }
 

--- a/test/Exception/CyclicAliasExceptionTest.php
+++ b/test/Exception/CyclicAliasExceptionTest.php
@@ -18,137 +18,86 @@ class CyclicAliasExceptionTest extends TestCase
     /**
      * @dataProvider aliasesProvider
      *
+     * @param string   conflicting alias key
      * @param string[] $aliases
      * @param string   $expectedMessage
      *
      * @return void
      */
-    public function testFromAliasesMap(array $aliases, $expectedMessage)
+    public function testFromCyclicAlias($alias, array $aliases, $expectedMessage)
     {
-        $exception = CyclicAliasException::fromAliasesMap($aliases);
+        $exception = CyclicAliasException::fromCyclicAlias($alias, $aliases);
 
         self::assertInstanceOf(CyclicAliasException::class, $exception);
-        self::assertSame($expectedMessage, $exception->getMessage());
+        self::assertSame($expectedMessage, $exception->getCycle());
     }
 
     /**
+     * Test data provider for testFromCyclicAlias
+     *
      * @return string[][]|string[][][]
      */
     public function aliasesProvider()
     {
-        return [
-            'empty set' => [
-                [],
-                'A cycle was detected within the following aliases map:
-
-[
-
-]'
-            ],
-            'acyclic set' => [
+        return
+        [
+            [
+                'a',
                 [
-                    'b' => 'a',
-                    'd' => 'c',
+                    'a' => 'a',
                 ],
-                'A cycle was detected within the following aliases map:
-
-[
-"b" => "a"
-"d" => "c"
-]'
+                "a -> a\n",
             ],
-            'acyclic self-referencing set' => [
+            [
+                'a',
                 [
-                    'b' => 'a',
-                    'c' => 'b',
-                    'd' => 'c',
-                ],
-                'A cycle was detected within the following aliases map:
-
-[
-"b" => "a"
-"c" => "b"
-"d" => "c"
-]'
-            ],
-            'cyclic set' => [
-                [
-                    'b' => 'a',
                     'a' => 'b',
+                    'b' => 'a'
                 ],
-                'Cycles were detected within the provided aliases:
-
-[
-"b" => "a" => "b"
-]
-
-The cycle was detected in the following alias map:
-
-[
-"b" => "a"
-"a" => "b"
-]'
+                "a -> b -> a\n",
             ],
-            'cyclic set (indirect)' => [
+            [
+                'b',
                 [
-                    'b' => 'a',
-                    'c' => 'b',
-                    'a' => 'c',
-                ],
-                'Cycles were detected within the provided aliases:
-
-[
-"b" => "a" => "c" => "b"
-]
-
-The cycle was detected in the following alias map:
-
-[
-"b" => "a"
-"c" => "b"
-"a" => "c"
-]'
-            ],
-            'cyclic set + acyclic set' => [
-                [
-                    'b' => 'a',
                     'a' => 'b',
-                    'd' => 'c',
+                    'b' => 'a'
                 ],
-                'Cycles were detected within the provided aliases:
-
-[
-"b" => "a" => "b"
-]
-
-The cycle was detected in the following alias map:
-
-[
-"b" => "a"
-"a" => "b"
-"d" => "c"
-]'
+                "b -> a -> b\n",
             ],
-            'cyclic set + reference to cyclic set' => [
+            [
+                'b',
                 [
-                    'b' => 'a',
                     'a' => 'b',
+                    'b' => 'a',
+                ],
+                "b -> a -> b\n",
+            ],
+            [
+                'a',
+                [
+                    'a' => 'b',
+                    'b' => 'c',
                     'c' => 'a',
                 ],
-                'Cycles were detected within the provided aliases:
-
-[
-"b" => "a" => "b"
-"c" => "a" => "b" => "c"
-]
-
-The cycle was detected in the following alias map:
-
-[
-"b" => "a"
-"a" => "b"
-"c" => "a"
-]'
+                "a -> b -> c -> a\n",
+            ],
+            [
+                'b',
+                [
+                    'a' => 'b',
+                    'b' => 'c',
+                    'c' => 'a',
+                ],
+                "b -> c -> a -> b\n",
+            ],
+            [
+                'c',
+                [
+                    'a' => 'b',
+                    'b' => 'c',
+                    'c' => 'a',
+                ],
+                "c -> a -> b -> c\n",
             ],
         ];
     }

--- a/test/Exception/CyclicAliasExceptionTest.php
+++ b/test/Exception/CyclicAliasExceptionTest.php
@@ -19,11 +19,9 @@ class CyclicAliasExceptionTest extends TestCase
     /**
      * @dataProvider cyclicAliasProvider
      *
-     * @param string   conflicting alias key
+     * @param string   $alias, conflicting alias key
      * @param string[] $aliases
      * @param string   $expectedMessage
-     *
-     * @return void
      */
     public function testFromCyclicAlias($alias, array $aliases, $expectedMessage)
     {
@@ -40,8 +38,7 @@ class CyclicAliasExceptionTest extends TestCase
      */
     public function cyclicAliasProvider()
     {
-        return
-        [
+        return [
             [
                 'a',
                 [
@@ -115,8 +112,6 @@ class CyclicAliasExceptionTest extends TestCase
      *
      * @param string[] $aliases
      * @param string   $expectedMessage
-     *
-     * @return void
      */
     public function testFromAliasesMap(array $aliases, $expectedMessage)
     {

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -272,11 +272,6 @@ class ServiceManagerTest extends TestCase
         self::assertSame($service, $headAlias);
     }
 
-    public function emulateHas($name)
-    {
-        return $name === 'ServiceName';
-    }
-
     public function testAbstractFactoryShouldBeCheckedForResolvedAliasesInsteadOfAliasName()
     {
         $abstractFactory = $this->createMock(AbstractFactoryInterface::class);

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -272,6 +272,11 @@ class ServiceManagerTest extends TestCase
         self::assertSame($service, $headAlias);
     }
 
+    public function emulateHas($name)
+    {
+        return $name === 'ServiceName';
+    }
+
     public function testAbstractFactoryShouldBeCheckedForResolvedAliasesInsteadOfAliasName()
     {
         $abstractFactory = $this->createMock(AbstractFactoryInterface::class);
@@ -285,12 +290,18 @@ class ServiceManagerTest extends TestCase
             ],
         ]);
 
-        $abstractFactory
-            ->expects(self::once())
-            ->method('canCreate')
-            ->with($this->anything())
-            ->willReturn($this->equalTo('ServiceName'));
+        $valueMap = [
+            ['Alias', false],
+            ['ServiceName', true],
+        ];
 
+        $abstractFactory
+            ->method('canCreate')
+            ->withConsecutive(
+                [ $this->anything(), $this->equalTo('Alias') ],
+                [ $this->anything(), $this->equalTo('ServiceName')]
+            )
+            ->willReturn($this->returnValueMap($valueMap));
         $this->assertTrue($serviceManager->has('Alias'));
     }
 

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -272,7 +272,7 @@ class ServiceManagerTest extends TestCase
         self::assertSame($service, $headAlias);
     }
 
-    public function testAbstractFactoryShouldBeCheckedForResolvedAliasesInsteadOfAliasNameName()
+    public function testAbstractFactoryShouldBeCheckedForResolvedAliasesInsteadOfAliasName()
     {
         $abstractFactory = $this->createMock(AbstractFactoryInterface::class);
 
@@ -288,8 +288,8 @@ class ServiceManagerTest extends TestCase
         $abstractFactory
             ->expects(self::once())
             ->method('canCreate')
-            ->with(self::anything(), 'ServiceName')
-            ->willReturn(true);
+            ->with($this->anything())
+            ->willReturn($this->equalTo('ServiceName'));
 
         $this->assertTrue($serviceManager->has('Alias'));
     }


### PR DESCRIPTION
This PR is about performance of the setter APIs (or injector APIs if you like) as well as has(). Here's the current comparison report. Thanks @dantleech for faster than light fix.

	benchmark: SetNewServicesBench
	+------------------------+--------------------+------------------+--------+
	| subject                | suite:develop:mean | suite:PR221:mean | gain   |
	+------------------------+--------------------+------------------+--------+
	| benchSetService        | 1.924µs            | 0.655µs          |  2,94x |
	| benchSetFactory        | 4.183µs            | 1.226µs          |  3,41x |
	| benchSetAlias          | 11.222µs           | 1.872µs          |  5,99x |
	| benchSetAliasOverrided | 34.617µs           | 1.876µs          | 18,45x |
	+------------------------+--------------------+------------------+--------+

This is the develop branch:

	Dumped result to SetNewServices.develop.xml
	suite: 133ec8900bdebd2cfb961e09ca103052bd993f16, date: 2018-01-05, stime: 22:12:29
	+---------------------+------------------------+--------+--------+--------+-----+------------+-------------+-------------+-------------+-------------+------------+--------+--------+
	| benchmark           | subject                | groups | params | revs   | its | mem_peak   | best        | mean        | mode        | worst       | stdev      | rstdev | diff   |
	+---------------------+------------------------+--------+--------+--------+-----+------------+-------------+-------------+-------------+-------------+------------+--------+--------+
	| SetNewServicesBench | benchSetService        |        | []     | 100000 | 100 | 1,375,992b | 1.910110µs  | 1.957413µs  | 1.946003µs  | 2.050120µs  | 0.028245µs | 1.44%  | 1.00x  |
	| SetNewServicesBench | benchSetFactory        |        | []     | 100000 | 100 | 1,375,992b | 4.180240µs  | 4.240743µs  | 4.229557µs  | 4.420250µs  | 0.030047µs | 0.71%  | 2.17x  |
	| SetNewServicesBench | benchSetAlias          |        | []     | 100000 | 100 | 1,375,992b | 11.440650µs | 11.625965µs | 11.601287µs | 12.160700µs | 0.099540µs | 0.86%  | 5.94x  |
	| SetNewServicesBench | benchSetAliasOverrided |        | []     | 100000 | 100 | 1,376,000b | 35.572030µs | 35.950056µs | 35.759907µs | 37.172120µs | 0.312706µs | 0.87%  | 18.37x |
	+---------------------+------------------------+--------+--------+--------+-----+------------+-------------+-------------+-------------+-------------+------------+--------+--------+

Here comes this PR:

	Dumped result to SetNewServices.setAlias.xml
	suite: 133ec89fee8638dd6d892c639ca0556b8090f9b8, date: 2018-01-05, stime: 21:42:44
	+---------------------+------------------------+--------+--------+--------+-----+------------+------------+------------+------------+------------+------------+--------+-------+
	| benchmark           | subject                | groups | params | revs   | its | mem_peak   | best       | mean       | mode       | worst      | stdev      | rstdev | diff  |
	+---------------------+------------------------+--------+--------+--------+-----+------------+------------+------------+------------+------------+------------+--------+-------+
	| SetNewServicesBench | benchSetService        |        | []     | 100000 | 100 | 1,347,528b | 0.640030µs | 0.654438µs | 0.650130µs | 0.680040µs | 0.010230µs | 1.56%  | 1.00x |
	| SetNewServicesBench | benchSetFactory        |        | []     | 100000 | 100 | 1,347,528b | 1.200070µs | 1.222270µs | 1.217291µs | 1.280070µs | 0.013681µs | 1.12%  | 1.87x |
	| SetNewServicesBench | benchSetAlias          |        | []     | 100000 | 100 | 1,347,528b | 1.810100µs | 1.845307µs | 1.848852µs | 1.900110µs | 0.015841µs | 0.86%  | 2.82x |
	| SetNewServicesBench | benchSetAliasOverrided |        | []     | 100000 | 100 | 1,347,536b | 1.780100µs | 1.803603µs | 1.794896µs | 1.870110µs | 0.019256µs | 1.07%  | 2.76x |
	+---------------------+------------------------+--------+--------+--------+-----+------------+------------+------------+------------+------------+------------+--------+-------+
  
  
  
  
  