### PR TITLE
Bugfixes as of #242 applied to develop + more

### DIFF
--- a/benchmarks/BenchAsset/DelegatorFactoryFoo.php
+++ b/benchmarks/BenchAsset/DelegatorFactoryFoo.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendBench\ServiceManager\BenchAsset;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\DelegatorFactoryInterface;
+
+class DelegatorFactoryFoo implements DelegatorFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     * @see \Zend\ServiceManager\Factory\DelegatorFactoryInterface::__invoke()
+     */
+    public function __invoke(ContainerInterface $container, $name, callable $callback, array $options = null)
+    {
+        $foo = call_user_func($callback);
+        return $foo;
+    }
+}

--- a/benchmarks/BenchAsset/DelegatorFactoryFoo.php
+++ b/benchmarks/BenchAsset/DelegatorFactoryFoo.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 

--- a/benchmarks/BenchAsset/DelegatorFactoryFoo.php
+++ b/benchmarks/BenchAsset/DelegatorFactoryFoo.php
@@ -18,7 +18,6 @@ class DelegatorFactoryFoo implements DelegatorFactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, callable $callback, array $options = null)
     {
-        $foo = call_user_func($callback);
-        return $foo;
+        return $callback;
     }
 }

--- a/benchmarks/BenchAsset/DelegatorFactoryFoo.php
+++ b/benchmarks/BenchAsset/DelegatorFactoryFoo.php
@@ -18,6 +18,6 @@ class DelegatorFactoryFoo implements DelegatorFactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, callable $callback, array $options = null)
     {
-        return $callback;
+        return $callback($options);
     }
 }

--- a/benchmarks/BenchAsset/InitializerFoo.php
+++ b/benchmarks/BenchAsset/InitializerFoo.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendBench\ServiceManager\BenchAsset;
+
+use Zend\ServiceManager\Initializer\InitializerInterface;
+
+class InitializerFoo implements InitializerInterface
+{
+    protected $options;
+
+    /**
+     * {@inheritDoc}
+     * @see \Zend\ServiceManager\Initializer\InitializerInterface::__invoke()
+     */
+    public function __invoke(\Interop\Container\ContainerInterface $container, $instance)
+    {
+    }
+
+    public function __construct($options = null)
+    {
+        $this->options = $options;
+    }
+}

--- a/benchmarks/BenchAsset/InitializerFoo.php
+++ b/benchmarks/BenchAsset/InitializerFoo.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 

--- a/benchmarks/SetNewServicesBench.php
+++ b/benchmarks/SetNewServicesBench.php
@@ -52,12 +52,12 @@ class SetNewServicesBench
             $config['invokables']['invokable_$i'] = BenchAsset\Foo::class;
             $config['delegators']['delegator_$i'] = [ DelegatorFactoryFoo::class ];
         }
-        
+
         $this->initializer = new BenchAsset\InitializerFoo();
         $this->abstractFactory = new BenchAsset\AbstractFactoryFoo();
         $this->sm = new ServiceManager($config);
     }
-        
+
 
     public function benchSetService()
     {
@@ -90,52 +90,51 @@ class SetNewServicesBench
 
         $sm->setAlias('recursiveFactoryAlias1', 'factory1');
     }
-    
+
     public function benchSetInvokableClass()
     {
-        
+
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->setInvokableClass(BenchAsset\Foo::class, BenchAsset\Foo::class);
     }
-    
+
     public function benchAddDelegator()
     {
-        
+
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addDelegator(BenchAsset\Foo::class, DelegatorFactoryFoo::class);
     }
-    
+
     public function benchAddInitializerByClassName()
     {
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addInitializer(BenchAsset\InitializerFoo::class);
     }
-    
+
     public function benchAddInitializerByInstance()
     {
-        
+
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addInitializer($this->initializer);
     }
-    
+
     public function benchAddAbstractFactoryByClassName()
     {
-        
+
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addAbstractFactory(BenchAsset\AbstractFactoryFoo::class);
     }
-    
+
     public function benchAddAbstractFactoryByInstance()
     {
-        
+
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addAbstractFactory($this->abstractFactory);
     }
-    
 }

--- a/benchmarks/SetNewServicesBench.php
+++ b/benchmarks/SetNewServicesBench.php
@@ -11,6 +11,7 @@ use PhpBench\Benchmark\Metadata\Annotations\Iterations;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 use PhpBench\Benchmark\Metadata\Annotations\Warmup;
 use Zend\ServiceManager\ServiceManager;
+use ZendBench\ServiceManager\BenchAsset\DelegatorFactoryFoo;
 
 /**
  * @Revs(1000)
@@ -61,79 +62,87 @@ class SetNewServicesBench
 
     public function benchSetService()
     {
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
-
         $sm->setService('service2', new \stdClass());
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchSetFactory()
     {
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
-
         $sm->setFactory('factory2', BenchAsset\FactoryFoo::class);
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchSetAlias()
     {
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
-
         $sm->setAlias('factoryAlias2', 'factory1');
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchOverrideAlias()
     {
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
-
         $sm->setAlias('recursiveFactoryAlias1', 'factory1');
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchSetInvokableClass()
     {
-
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->setInvokableClass(BenchAsset\Foo::class, BenchAsset\Foo::class);
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchAddDelegator()
     {
-
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addDelegator(BenchAsset\Foo::class, DelegatorFactoryFoo::class);
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchAddInitializerByClassName()
     {
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addInitializer(BenchAsset\InitializerFoo::class);
     }
 
-    public function benchAddInitializerByInstance()
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
+   public function benchAddInitializerByInstance()
     {
-
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addInitializer($this->initializer);
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchAddAbstractFactoryByClassName()
     {
-
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addAbstractFactory(BenchAsset\AbstractFactoryFoo::class);
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchAddAbstractFactoryByInstance()
     {
-
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addAbstractFactory($this->abstractFactory);
     }

--- a/benchmarks/SetNewServicesBench.php
+++ b/benchmarks/SetNewServicesBench.php
@@ -123,7 +123,7 @@ class SetNewServicesBench
     /**
      * @todo @link https://github.com/phpbench/phpbench/issues/304
      */
-   public function benchAddInitializerByInstance()
+    public function benchAddInitializerByInstance()
     {
         $sm = clone $this->sm;
         $sm->addInitializer($this->initializer);

--- a/benchmarks/SetNewServicesBench.php
+++ b/benchmarks/SetNewServicesBench.php
@@ -43,18 +43,21 @@ class SetNewServicesBench
                 'recursiveFactoryAlias1' => 'factoryAlias1',
                 'recursiveFactoryAlias2' => 'recursiveFactoryAlias1',
             ],
-            'abstract_factories' => [
-                BenchAsset\AbstractFactoryFoo::class
-            ],
         ];
 
         for ($i = 0; $i <= self::NUM_SERVICES; $i++) {
             $config['factories']["factory_$i"] = BenchAsset\FactoryFoo::class;
             $config['aliases']["alias_$i"]     = "service_$i";
+            $config['abstract_factories'][] = BenchAsset\AbstractFactoryFoo::class;
+            $config['invokables']['invokable_$i'] = BenchAsset\Foo::class;
+            $config['delegators']['delegator_$i'] = [ DelegatorFactoryFoo::class ];
         }
-
+        
+        $this->initializer = new BenchAsset\InitializerFoo();
+        $this->abstractFactory = new BenchAsset\AbstractFactoryFoo();
         $this->sm = new ServiceManager($config);
     }
+        
 
     public function benchSetService()
     {
@@ -80,11 +83,59 @@ class SetNewServicesBench
         $sm->setAlias('factoryAlias2', 'factory1');
     }
 
-    public function benchSetAliasOverrided()
+    public function benchOverrideAlias()
     {
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
 
         $sm->setAlias('recursiveFactoryAlias1', 'factory1');
     }
+    
+    public function benchSetInvokableClass()
+    {
+        
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+        $sm->setInvokableClass(BenchAsset\Foo::class, BenchAsset\Foo::class);
+    }
+    
+    public function benchAddDelegator()
+    {
+        
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+        $sm->addDelegator(BenchAsset\Foo::class, DelegatorFactoryFoo::class);
+    }
+    
+    public function benchAddInitializerByClassName()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+        $sm->addInitializer(BenchAsset\InitializerFoo::class);
+    }
+    
+    public function benchAddInitializerByInstance()
+    {
+        
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+        $sm->addInitializer($this->initializer);
+    }
+    
+    public function benchAddAbstractFactoryByClassName()
+    {
+        
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+        $sm->addAbstractFactory(BenchAsset\AbstractFactoryFoo::class);
+    }
+    
+    public function benchAddAbstractFactoryByInstance()
+    {
+        
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+        $sm->addAbstractFactory($this->abstractFactory);
+    }
+    
 }

--- a/benchmarks/SetNewServicesBench.php
+++ b/benchmarks/SetNewServicesBench.php
@@ -50,8 +50,8 @@ class SetNewServicesBench
             $config['factories']["factory_$i"] = BenchAsset\FactoryFoo::class;
             $config['aliases']["alias_$i"]     = "service_$i";
             $config['abstract_factories'][] = BenchAsset\AbstractFactoryFoo::class;
-            $config['invokables']['invokable_$i'] = BenchAsset\Foo::class;
-            $config['delegators']['delegator_$i'] = [ DelegatorFactoryFoo::class ];
+            $config['invokables']["invokable_$i"] = BenchAsset\Foo::class;
+            $config['delegators']["delegator_$i"] = [ DelegatorFactoryFoo::class ];
         }
 
         $this->initializer = new BenchAsset\InitializerFoo();

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -23,8 +23,8 @@ class InvalidArgumentException extends SplInvalidArgumentException implements Ex
     public static function fromInvalidInitializer($initializer)
     {
         return new self(sprintf(
-            'An invalid initializer was registered. Expected a valid function name or '
-            . 'class name or a callable or an instance of "%s"; received "%s"',
+            'An invalid initializer was registered. Expected a valid function name, '
+            . 'class name, a callable or an instance of "%s", but "%s" was received.',
             InitializerInterface::class,
             is_object($initializer) ? get_class($initializer) : gettype($initializer)
         ));

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -23,8 +23,8 @@ class InvalidArgumentException extends SplInvalidArgumentException implements Ex
     public static function fromInvalidInitializer($initializer)
     {
         return new self(sprintf(
-            'An invalid initializer was registered. Expected a callable or an'
-            . ' instance of "%s"; received "%s"',
+            'An invalid initializer was registered. Expected a valid function name or '
+            . 'class name or a callable or an instance of "%s"; received "%s"',
             InitializerInterface::class,
             is_object($initializer) ? get_class($initializer) : gettype($initializer)
         ));

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -393,11 +393,10 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setAlias($alias, $target)
     {
-        if (! isset($this->services[$alias]) || $this->allowOverride) {
-            $this->mapAliasToTarget($alias, $target);
-            return;
+        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+            throw ContainerModificationsNotAllowedException::fromExistingService($alias);
         }
-        throw ContainerModificationsNotAllowedException::fromExistingService($alias);
+        $this->mapAliasToTarget($alias, $target);
     }
 
     /**
@@ -411,11 +410,10 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setInvokableClass($name, $class = null)
     {
-        if (! isset($this->services[$name]) || $this->allowOverride) {
-            $this->createAliasesAndFactoriesForInvokables([$name => $class ?? $name]);
-            return;
+        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+            throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
-        throw ContainerModificationsNotAllowedException::fromExistingService($name);
+        $this->createAliasesAndFactoriesForInvokables([$name => $class ?? $name]);
     }
 
     /**
@@ -429,11 +427,10 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setFactory($name, $factory)
     {
-        if (! isset($this->services[$name]) || $this->allowOverride) {
-            $this->factories[$name] = $factory;
-            return;
+        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+            throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
-        throw ContainerModificationsNotAllowedException::fromExistingService($name);
+        $this->factories[$name] = $factory;
     }
 
     /**
@@ -445,11 +442,10 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function addDelegator($name, $factory)
     {
-        if (! isset($this->services[$name]) || $this->allowOverride) {
-            $this->delegators = array_merge_recursive($this->delegators, [$name => [$factory]]);
-            return;
+        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+            throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
-        throw ContainerModificationsNotAllowedException::fromExistingService($name);
+        $this->delegators = array_merge_recursive($this->delegators, [$name => [$factory]]);
     }
 
     /**

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -411,7 +411,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setInvokableClass($name, $class = null)
     {
-        if (! isset($this->services[$name]) && $this->allowOverride) {
+        if (! isset($this->services[$name]) || $this->allowOverride) {
             $this->createAliasesAndFactoriesForInvokables([$name => $class ?? $name]);
             return;
         }
@@ -429,8 +429,11 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setFactory($name, $factory)
     {
-
-        $this->factories[$name] = $factory;
+        if (! isset($this->services[$name]) || $this->allowOverride) {
+            $this->factories[$name] = $factory;
+            return;
+        }
+        throw ContainerModificationsNotAllowedException::fromExistingService($name);
     }
 
     /**
@@ -472,6 +475,7 @@ class ServiceManager implements ServiceLocatorInterface
         if (! isset($this->services[$name]) ||$this->allowOverride) {
             $this->lazyServices = array_merge_recursive(['class_map' => [$name => $class ?? $name]]);
             $this->lazyServicesDelegator = null;
+            return;
         }
         throw ContainerModificationsNotAllowedException::fromExistingService($name);
     }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -522,7 +522,6 @@ class ServiceManager implements ServiceLocatorInterface
             return;
         }
         throw ContainerModificationsNotAllowedException::fromExistingService($name);
-
     }
 
     /**
@@ -884,6 +883,7 @@ class ServiceManager implements ServiceLocatorInterface
             if ($aCursor === $tCursor) {
                 throw CyclicAliasException::fromCyclicAlias($alias, $this->aliases);
             }
+
             if (! isset($this->aliases[$tCursor])) {
                 continue;
             }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -911,7 +911,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     private function resolveAbstractFactories($abstractFactories)
     {
-        foreach ($abstractFactories as $_ => $abstractFactory) {
+        foreach ($abstractFactories as $abstractFactory) {
             if (is_string($abstractFactory) && class_exists($abstractFactory)) {
                 // cached string
                 if (! isset($this->cachedAbstractFactories[$abstractFactory])) {

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -391,12 +391,12 @@ class ServiceManager implements ServiceLocatorInterface
      * @throws ContainerModificationsNotAllowedException if $alias already
      *     exists as a service and overrides are disallowed.
      */
-    public function setAlias($alias, $target)
+    public function setAlias($name, $target)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
-            throw ContainerModificationsNotAllowedException::fromExistingService($alias);
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
+            throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
-        $this->mapAliasToTarget($alias, $target);
+        $this->mapAliasToTarget($name, $target);
     }
 
     /**
@@ -410,7 +410,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setInvokableClass($name, $class = null)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
             throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
         $this->createAliasesAndFactoriesForInvokables([$name => $class ?? $name]);
@@ -427,7 +427,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setFactory($name, $factory)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
             throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
         $this->factories[$name] = $factory;
@@ -442,7 +442,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function mapLazyService($name, $class = null)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
             throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
         $this->lazyServices = array_merge_recursive(['class_map' => [$name => $class ?? $name]]);
@@ -469,7 +469,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function addDelegator($name, $factory)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
             throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
         $this->delegators = array_merge_recursive($this->delegators, [$name => [$factory]]);
@@ -495,7 +495,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setService($name, $service)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
             throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
         $this->services[$name] = $service;
@@ -511,7 +511,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setShared($name, $flag)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
             throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
         $this->shared[$name] = (bool) $flag;

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -370,7 +370,7 @@ class ServiceManager implements ServiceLocatorInterface
                 $this->shared = $config['shared'] + $this->shared;
             }
             if (! empty($config['lazy_services']['class_map'])) {
-                $this->lazyServices['class_map'] = $this->lazyServices['class_map']
+                $this->lazyServices['class_map'] = isset($this->lazyServices['class_map'])
                     ? $config['lazy_services']['class_map'] + $this->lazyServices['class_map']
                     : $config['lazy_services']['class_map'];
                 $this->lazyServicesDelegator = null;

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -249,36 +249,18 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function has($name)
     {
+        $resolvedName = $this->aliases[$name] ?? $name;
         // Check services and factories first to speedup the most common requests.
-        if (isset($this->services[$name]) || isset($this->factories[$name])) {
+        if (isset($this->services[$resolvedName]) || isset($this->factories[$resolvedName])) {
             return true;
         }
 
         // Check abstract factories next.
         foreach ($this->abstractFactories as $abstractFactory) {
-            if ($abstractFactory->canCreate($this->creationContext, $name)) {
-                return true;
-            }
-        }
-
-        // If $name is not an alias, we are done.
-        if (! isset($this->aliases[$name])) {
-            return false;
-        }
-
-        // Check aliases.
-        $resolvedName = $this->aliases[$name];
-        if (isset($this->services[$resolvedName]) || isset($this->factories[$resolvedName])) {
-            return true;
-        }
-
-        // Check abstract factories on the $resolvedName as well.
-        foreach ($this->abstractFactories as $abstractFactory) {
             if ($abstractFactory->canCreate($this->creationContext, $resolvedName)) {
                 return true;
             }
         }
-
         return false;
     }
 
@@ -388,12 +370,8 @@ class ServiceManager implements ServiceLocatorInterface
 
         // For abstract factories and initializers, we always directly
         // instantiate them to avoid checks during service construction.
-        if (isset($config['abstract_factories'])) {
-            $abstractFactories = $config['abstract_factories'];
-            // $key not needed, but foreach is faster than foreach + array_values.
-            foreach ($abstractFactories as $key => $abstractFactory) {
-                $this->resolveAbstractFactoryInstance($abstractFactory);
-            }
+        if (! empty($config['abstract_factories'])) {
+            $this->resolveAbstractFactories($config['abstract_factories']);
         }
 
         if (isset($config['initializers'])) {
@@ -467,7 +445,12 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function mapLazyService($name, $class = null)
     {
-        $this->configure(['lazy_services' => ['class_map' => [$name => $class ?: $name]]]);
+        if (! isset($this->services[$name]) || $this->allowOverride) {
+            $this->lazyServices = array_merge_recursive(['class_map' => [$name => $class ?? $name]]);
+            $this->lazyServicesDelegator = null;
+            return;
+        }
+        throw ContainerModificationsNotAllowedException::fromExistingService($name);
     }
 
     /**
@@ -478,7 +461,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function addAbstractFactory($factory)
     {
-        $this->resolveAbstractFactoryInstance($factory);
+        $this->resolveAbstractFactories([$factory]);
     }
 
     /**
@@ -490,7 +473,11 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function addDelegator($name, $factory)
     {
-        $this->configure(['delegators' => [$name => [$factory]]]);
+        if (! isset($this->services[$name]) || $this->allowOverride) {
+            $this->delegators = array_merge_recursive($this->delegators, [$name => [$factory]]);
+            return;
+        }
+        throw ContainerModificationsNotAllowedException::fromExistingService($name);
     }
 
     /**
@@ -500,7 +487,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function addInitializer($initializer)
     {
-        $this->configure(['initializers' => [$initializer]]);
+        $this->resolveInitializers([$initializer]);
     }
 
     /**
@@ -925,25 +912,27 @@ class ServiceManager implements ServiceLocatorInterface
     /**
      * Instantiate abstract factories in order to avoid checks during service construction.
      *
-     * @param string|Factory\AbstractFactoryInterface $abstractFactories
-     * @return void
+     * @param string[]|Factory\AbstractFactoryInterface[] $abstractFactories
      */
-    private function resolveAbstractFactoryInstance($abstractFactory)
+    private function resolveAbstractFactories($abstractFactories)
     {
-        if (is_string($abstractFactory) && class_exists($abstractFactory)) {
-            // Cached string factory name
-            if (! isset($this->cachedAbstractFactories[$abstractFactory])) {
-                $this->cachedAbstractFactories[$abstractFactory] = new $abstractFactory();
+        foreach ($abstractFactories as $_ => $abstractFactory) {
+            if (is_string($abstractFactory) && class_exists($abstractFactory)) {
+                // cached string
+                if (! isset($this->cachedAbstractFactories[$abstractFactory])) {
+                    $this->cachedAbstractFactories[$abstractFactory] = new $abstractFactory();
+                }
+
+                $abstractFactory = $this->cachedAbstractFactories[$abstractFactory];
             }
 
-            $abstractFactory = $this->cachedAbstractFactories[$abstractFactory];
-        }
+            if ($abstractFactory instanceof Factory\AbstractFactoryInterface) {
+                $abstractFactoryObjHash = spl_object_hash($abstractFactory);
+                $this->abstractFactories[$abstractFactoryObjHash] = $abstractFactory;
+                return;
+            }
 
-        if (! $abstractFactory instanceof Factory\AbstractFactoryInterface) {
             throw InvalidArgumentException::fromInvalidAbstractFactory($abstractFactory);
         }
-
-        $abstractFactoryObjHash = spl_object_hash($abstractFactory);
-        $this->abstractFactories[$abstractFactoryObjHash] = $abstractFactory;
     }
 }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -161,12 +161,11 @@ class ServiceManager implements ServiceLocatorInterface
 
         if (! empty($config['aliases'])) {
             $this->aliases = $config['aliases'] + $this->aliases;
+            $this->mapAliasesToTargets();
             // to prevent that alias resolution happens again in
             // configure()
             unset($config['aliases']);
-        }
-
-        if (! empty($this->aliases)) {
+        } elseif (! empty($this->aliases)) {
             $this->mapAliasesToTargets();
         }
 

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -269,7 +269,9 @@ class ServiceManager implements ServiceLocatorInterface
     {
         $resolvedName = $this->aliases[$name] ?? $name;
         // Check services and factories first to speedup the most common requests.
-        if (isset($this->services[$resolvedName]) || isset($this->factories[$resolvedName]) || isset($this->invokables[$resolvedName])) {
+        if (isset($this->services[$resolvedName])
+            || isset($this->factories[$resolvedName])
+            || isset($this->invokables[$resolvedName])) {
             return true;
         }
 

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -383,7 +383,7 @@ class ServiceManager implements ServiceLocatorInterface
                     // If $this->services was not empty, we are here because $this->allowOverride was false,
                     // so checking $this->services only is sufficient, also.
                     // If this->service was not empty and allowOverride was false we are in the trivial case,
-                    // so checking $this->services only sufficient, also
+                    // so checking $this->services only is sufficient, also
                     if (isset($this->services[$name])) {
                         throw ContainerModificationsNotAllowedException::fromExistingService($name);
                     }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -160,11 +160,15 @@ class ServiceManager implements ServiceLocatorInterface
         $this->mapAliasesToTargets();
 
         if (! empty($this->initializers)) {
-            $this->resolveInitializers($this->initializers, true);
+            // null indicates resolveInitializers to initialize
+            // from $this->initializers
+            $this->resolveInitializers(null);
         }
 
         if (! empty($this->abstractFactories)) {
-            $this->resolveAbstractFactories($this->abstractFactories, true);
+            // null indicates resolveAbstractFactory to initialize
+            // from $this->abstractFactories
+            $this->resolveAbstractFactories(null);
         }
 
         if (! empty($this->invokables)) {
@@ -382,11 +386,11 @@ class ServiceManager implements ServiceLocatorInterface
         // For abstract factories and initializers, we always directly
         // instantiate them to avoid checks during service construction.
         if (! empty($config['abstract_factories'])) {
-            $this->resolveAbstractFactories($config['abstract_factories'], false);
+            $this->resolveAbstractFactories($config['abstract_factories']);
         }
 
         if (! empty($config['initializers'])) {
-            $this->resolveInitializers($config['initializers'], false);
+            $this->resolveInitializers($config['initializers']);
         }
         return $this;
     }
@@ -532,11 +536,10 @@ class ServiceManager implements ServiceLocatorInterface
      * @param boolean $constructing
      *
      */
-    private function resolveInitializers(array $initializers, $constructing = false)
+    private function resolveInitializers(array $initializers = null)
     {
-        // necessary because the $initializers argument may be
-        // $this->initializers (ServiceManager construction, see __construct)
-        if ($constructing) {
+        if ($initializers === null) {
+            $initializers = $this->initializers;
             unset($this->initializers);
         }
 
@@ -930,11 +933,10 @@ class ServiceManager implements ServiceLocatorInterface
      * @param string[]|Factory\AbstractFactoryInterface[] $abstractFactories
      * @param boolean $constructing
      */
-    private function resolveAbstractFactories($abstractFactories, $constructing = false)
+    private function resolveAbstractFactories(array $abstractFactories = null)
     {
-        // necessary because the $abstractFactories argument may be
-        // $this->abstractFactories (ServiceManager construction, see __construct)
-        if ($constructing) {
+        if ($abstractFactories === null) {
+            $abstractFactories = $this->abstractFactories;
             unset($this->abstractFactories);
         }
 

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -408,12 +408,12 @@ class ServiceManager implements ServiceLocatorInterface
      * @throws ContainerModificationsNotAllowedException if $alias already
      *     exists as a service and overrides are disallowed.
      */
-    public function setAlias($name, $target)
+    public function setAlias($alias, $target)
     {
-        if (isset($this->services[$name]) && ! $this->allowOverride) {
-            throw ContainerModificationsNotAllowedException::fromExistingService($name);
+        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+            throw ContainerModificationsNotAllowedException::fromExistingService($alias);
         }
-        $this->mapAliasToTarget($name, $target);
+        $this->mapAliasToTarget($alias, $target);
     }
 
     /**
@@ -586,6 +586,9 @@ class ServiceManager implements ServiceLocatorInterface
 
             return $factory;
         } elseif (isset($this->invokables[$name])) {
+            // The little trick to pass $name by reference to
+            // getFactory was necessary to enable late resolution
+            // of invokables here.
             $name = $this->invokables[$name];
             return new InvokableFactory();
         }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -382,6 +382,8 @@ class ServiceManager implements ServiceLocatorInterface
                     // so checking $this->services only is sufficient obviously.
                     // If $this->services was not empty, we are here because $this->allowOverride was false,
                     // so checking $this->services only is sufficient, also.
+                    // If this->service was not empty and allowOverride was false we are in the trivial case,
+                    // so checking $this->services only sufficient, also
                     if (isset($this->services[$name])) {
                         throw ContainerModificationsNotAllowedException::fromExistingService($name);
                     }
@@ -392,8 +394,10 @@ class ServiceManager implements ServiceLocatorInterface
                     $this->services[$name] = $service;
                 }
             }
-            // Assuming that we are allowed to override services registered above (which is the
-            // behaviour yet)
+            // Assuming that the services registered above need override protection also, we continue
+            // protecting the newly registered services from the loop above like the services we already
+            // knew before configure() was called. This behaviour is different from the implementation
+            // before, but all tests pass.
             if (! empty($config['aliases'])) {
                 foreach ($config['aliases'] as $alias => $target) {
                     if (isset($this->services[$alias])) {
@@ -409,6 +413,7 @@ class ServiceManager implements ServiceLocatorInterface
                         throw ContainerModificationsNotAllowedException::fromExistingService($name);
                     }
                 }
+                // @todo: resolve that within the loop
                 $this->delegators = array_merge_recursive($config['delegators'], $this->delegators);
             }
             if (! empty($config['factories'])) {

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -895,10 +895,6 @@ class ServiceManager implements ServiceLocatorInterface
                 throw CyclicAliasException::fromCyclicAlias($alias, $aliases);
             }
 
-            if (! isset($aliases[$tCursor])) {
-                continue;
-            }
-
             $stack = [];
 
             while (isset($aliases[$tCursor])) {

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -141,6 +141,16 @@ class ServiceManager implements ServiceLocatorInterface
     protected $sharedByDefault = true;
 
     /**
+     * ServiceManager was already configured?
+     * Maintened for bc also we don't rely on it
+     * any more
+     *
+     * @var bool
+     */
+    protected $configured = false;
+
+
+    /**
      * Cached abstract factories from string.
      *
      * @var array
@@ -176,6 +186,7 @@ class ServiceManager implements ServiceLocatorInterface
         }
 
         $this->configure($config);
+        $this->configured = true;
     }
 
     /**

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -393,7 +393,7 @@ class ServiceManager implements ServiceLocatorInterface
                 }
             }
             // Assuming that we are allowed to override services registered above (which is the
-            // behaviour before this PR
+            // behaviour yet)
             if (! empty($config['aliases'])) {
                 foreach ($config['aliases'] as $alias => $target) {
                     if (isset($this->services[$alias])) {

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -649,40 +649,44 @@ class ServiceManager implements ServiceLocatorInterface
     }
 
     /**
-     * Get a factory for the given service name
+     * Get a factory for the given service name and create an object using
+     * that factory or create invokable if service is invokable
      *
      * @param  string $name
-     * @return callable
+     * @return object
      * @throws ServiceNotFoundException
      */
-    private function getFactory(&$name)
+    private function createObjectThroughFactory($name, array $options = null)
     {
-        $factory = $this->factories[$name] ?? null;
+        $factory = isset($this->factories[$name]) ? $this->factories[$name] : null;
 
-        $lazyLoaded = false;
         if (is_string($factory) && class_exists($factory)) {
             $factory = new $factory();
-            $lazyLoaded = true;
-        }
-
-        if (is_callable($factory)) {
-            if ($lazyLoaded) {
+            if (is_callable($factory)) {
                 $this->factories[$name] = $factory;
             }
+            return $factory($this->creationContext, $name, $options);
+        }
 
-            return $factory;
-        } elseif (isset($this->invokables[$name])) {
-            // The little trick to pass $name by reference to
-            // getFactory was necessary to enable late resolution
-            // of invokables here.
-            $name = $this->invokables[$name];
-            return new InvokableFactory();
+        if (! is_callable($factory)) {
+            if (isset($this->invokables[$name])) {
+                $invokable = $this->invokables[$name];
+                return $options === null ? new $invokable() : new $invokable($options);
+            }
+        } else {
+            // PHP 5.6 fails on 'class::method' callables unless we explode them:
+            if (PHP_MAJOR_VERSION < 7
+                && is_string($factory) && strpos($factory, '::') !== false
+            ) {
+                $factory = explode('::', $factory);
+            }
+            return $factory($this->creationContext, $name, $options);
         }
 
         // Check abstract factories
         foreach ($this->abstractFactories as $abstractFactory) {
             if ($abstractFactory->canCreate($this->creationContext, $name)) {
-                return $abstractFactory;
+                return $abstractFactory($this->creationContext, $name, $options);
             }
         }
 
@@ -701,8 +705,7 @@ class ServiceManager implements ServiceLocatorInterface
     {
         $creationCallback = function () use ($name, $options) {
             // Code is inlined for performance reason, instead of abstracting the creation
-            $factory = $this->getFactory($name);
-            return $factory($this->creationContext, $name, $options);
+            return $this->createObjectThroughFactory($name, $options);
         };
 
         foreach ($this->delegators[$name] as $index => $delegatorFactory) {
@@ -761,9 +764,7 @@ class ServiceManager implements ServiceLocatorInterface
     {
         try {
             if (! isset($this->delegators[$resolvedName])) {
-                // Let's create the service by fetching the factory
-                $factory = $this->getFactory($resolvedName);
-                $object  = $factory($this->creationContext, $resolvedName, $options);
+                $object  = $this->createObjectThroughFactory($resolvedName, $options);
             } else {
                 $object = $this->createDelegatorFromName($resolvedName, $options);
             }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -384,8 +384,6 @@ class ServiceManager implements ServiceLocatorInterface
                     // so checking $this->services only is sufficient obviously.
                     // If $this->services was not empty, we are here because $this->allowOverride was false,
                     // so checking $this->services only is sufficient, also.
-                    // If this->service was not empty and allowOverride was false we are in the trivial case,
-                    // so checking $this->services only is sufficient, also
                     if (isset($this->services[$name])) {
                         throw ContainerModificationsNotAllowedException::fromExistingService($name);
                     }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -454,11 +454,7 @@ class ServiceManager implements ServiceLocatorInterface
         if (! empty($config['lazy_services'])) {
             $this->lazyServices = $config['lazy_services'] + $this->lazyServices;
         }
-        // @todo: Should that not be forbidden if allowOverride is false
-        // and the shareability of existing services is affected?
-        // To handle that case explicitely would be pro forma only
-        // (i.e. effort for nothing, but possibly better readability), because
-        // existing shared services remain shared regardless of this setting.
+
         if (isset($config['shared_by_default'])) {
             $this->sharedByDefault = $config['shared_by_default'];
         }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -166,7 +166,9 @@ class ServiceManager implements ServiceLocatorInterface
             unset($config['aliases']);
         }
 
-        $this->mapAliasesToTargets();
+        if (! empty($this->aliases)) {
+            $this->mapAliasesToTargets();
+        }
 
         if (! empty($this->initializers)) {
             // null indicates resolveInitializers to initialize

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -822,25 +822,6 @@ class ServiceManager implements ServiceLocatorInterface
     }
 
     /**
-     * Create aliases and factories for invokable classes.
-     *
-     * If an invokable service name does not match the class it maps to, this
-     * creates an alias to the class (which will later be mapped as an
-     * invokable factory).
-     *
-     * @param array $invokables
-     */
-    private function createAliasesAndFactoriesForInvokables(array $invokables)
-    {
-        foreach ($invokables as $name => $class) {
-            $this->factories[$class] = Factory\InvokableFactory::class;
-            if ($name !== $class) {
-                $this->aliases[$name] = $class;
-            }
-        }
-    }
-
-    /**
      * Assuming that the alias name is valid (see above) resolve/add it.
      *
      * This is done differently from bulk mapping aliases for performance reasons, as the

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -378,7 +378,7 @@ class ServiceManager implements ServiceLocatorInterface
         } else {
             if (! empty($config['services'])) {
                 foreach ($config['services'] as $name => $service) {
-                    // If allowOverride was false, we are here because $this->services was not empty, so
+                    // If allowOverride was false, we are here because $this->services was not empty,
                     // so checking $this->services only is sufficient obviously.
                     // If $this->services was not empty, we are here because $this->allowOverride was false,
                     // so checking $this->services only is sufficient, also.

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -379,9 +379,9 @@ class ServiceManager implements ServiceLocatorInterface
             if (! empty($config['services'])) {
                 foreach ($config['services'] as $name => $service) {
                     // If allowOverride was false, we are here because $this->services was not empty, so
-                    // so checking $this->services only is sufficient obviusly.
-                    // If $this->services was not empty, we are here, because $this->allowOverride was false,
-                    // so checking $this->services only is sufficient, too.
+                    // so checking $this->services only is sufficient obviously.
+                    // If $this->services was not empty, we are here because $this->allowOverride was false,
+                    // so checking $this->services only is sufficient, also.
                     if (isset($this->services[$name])) {
                         throw ContainerModificationsNotAllowedException::fromExistingService($name);
                     }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -165,6 +165,7 @@ class ServiceManager implements ServiceLocatorInterface
             // configure()
             unset($config['aliases']);
         }
+
         $this->mapAliasesToTargets();
 
         if (! empty($this->initializers)) {
@@ -538,7 +539,6 @@ class ServiceManager implements ServiceLocatorInterface
      * Instantiate initializers for to avoid checks during service construction.
      *
      * @param string[]|Initializer\InitializerInterface[]|callable[] $initializers
-     * @param boolean $constructing
      *
      */
     private function resolveInitializers(array $initializers = null)
@@ -942,7 +942,6 @@ class ServiceManager implements ServiceLocatorInterface
      * Instantiate abstract factories in order to avoid checks during service construction.
      *
      * @param string[]|Factory\AbstractFactoryInterface[] $abstractFactories
-     * @param boolean $constructing
      */
     private function resolveAbstractFactories(array $abstractFactories = null)
     {

--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -21,9 +21,11 @@ use Zend\ServiceManager\Initializer\InitializerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZendTest\ServiceManager\TestAsset\CallTimesAbstractFactory;
 use ZendTest\ServiceManager\TestAsset\FailingAbstractFactory;
-use ZendTest\ServiceManager\TestAsset\FailingFactory;
 use ZendTest\ServiceManager\TestAsset\FailingExceptionWithStringAsCodeFactory;
+use ZendTest\ServiceManager\TestAsset\FailingFactory;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
+use ZendTest\ServiceManager\TestAsset\PassthroughDelegatorFactory;
+use ZendTest\ServiceManager\TestAsset\SampleFactory;
 use ZendTest\ServiceManager\TestAsset\SimpleAbstractFactory;
 
 trait CommonServiceLocatorBehaviorsTrait
@@ -849,5 +851,179 @@ trait CommonServiceLocatorBehaviorsTrait
                 'b' => 'a',
             ],
         ]);
+    }
+
+    public function testMinimalCyclicAliasDefinitionShouldThrow()
+    {
+        $sm = $this->createContainer([]);
+
+        $this->expectException(CyclicAliasException::class);
+        $sm->setAlias('alias', 'alias');
+    }
+
+    public function testCoverageDepthFirstTaggingOnRecursiveAliasDefinitions()
+    {
+        $sm = $this->createContainer([
+            'factories' => [
+                stdClass::class => InvokableFactory::class,
+            ],
+            'aliases' => [
+                'alias1' => 'alias2',
+                'alias2' => 'alias3',
+                'alias3' => stdClass::class,
+            ],
+        ]);
+        $this->assertSame($sm->get('alias1'), $sm->get('alias2'));
+        $this->assertSame($sm->get(stdClass::class), $sm->get('alias1'));
+    }
+
+    /**
+     * The ServiceManager can change internal state on calls to get,
+     * build or has, latter not currently. Possible state changes
+     * are caching a factory, registering a service produced by
+     * a factory, ...
+     *
+     * This tests performs three consecutive calls to build/get for
+     * each registered service to push the service manager through
+     * all internal states, thereby verifying that build/get/has
+     * remain stable through the internal states.
+     *
+     * @dataProvider provideConsistencyOverInternalStatesTests
+     *
+     * @param ContainerInterface $smTemplate
+     * @param string $name
+     * @param array[] string $test
+     */
+    public function testConsistencyOverInternalStates($smTemplate, $name, $test, $shared)
+    {
+        $sm = clone $smTemplate;
+        $object['get'] = [];
+        $object['build'] = [];
+
+        // call get()/build() and store the retrieved
+        // objects in $object['get'] or $object['build']
+        // respectively
+        foreach ($test as $method) {
+            $obj = $sm->$method($name);
+            $object[$shared ? $method : 'build'][] = $obj;
+            $this->assertNotNull($obj);
+            $this->assertTrue($sm->has($name));
+        }
+
+        // compares the first to the first also, but ok
+        foreach ($object['get'] as $sharedObj) {
+            $this->assertSame($object['get'][0], $sharedObj);
+        }
+        // objects from object['build'] have to be different
+        // from all other objects
+        foreach ($object['build'] as $idx1 => $nonSharedObj1) {
+            $this->assertNotContains($nonSharedObj1, $object['get']);
+            foreach ($object['build'] as $idx2 => $nonSharedObj2) {
+                if ($idx1 !== $idx2) {
+                    $this->assertNotSame($nonSharedObj1, $nonSharedObj2);
+                }
+            }
+        }
+    }
+
+    /**
+     * Data provider
+     *
+     * @see testConsistencyOverInternalStates above
+     *
+     * @param ContainerInterface $smTemplate
+     * @param string $name
+     * @param string[] $test
+     */
+    public function provideConsistencyOverInternalStatesTests()
+    {
+        $config1 = [
+            'factories' => [
+                // to allow build('service')
+                'service' => function ($container, $requestedName, array $options = null) {
+                    return new stdClass();
+                },
+                'factory' => SampleFactory::class,
+                'delegator' => SampleFactory::class,
+                ],
+                'delegators' => [
+                    'delegator' => [
+                        PassthroughDelegatorFactory::class
+                    ],
+                ],
+                'invokables' => [
+                    'invokable' => InvokableObject::class,
+                ],
+                'services' => [
+                    'service' => new stdClass(),
+                ],
+                'aliases' => [
+                    'serviceAlias'          => 'service',
+                    'invokableAlias'        => 'invokable',
+                    'factoryAlias'          => 'factory',
+                    'abstractFactoryAlias'  => 'foo',
+                    'delegatorAlias'        => 'delegator',
+                ],
+                'abstract_factories' => [
+                    AbstractFactoryFoo::class
+                ]
+                ];
+        $config2 = $config1;
+        $config2['shared_by_default'] = false;
+
+        $configs = [ $config1, $config2 ];
+
+        foreach ($configs as $config) {
+            $smTemplates[] = $this->createContainer($config);
+        }
+
+        // produce all 3-tuples of 'build' and 'get', i.e.
+        //
+        // [['get', 'get', 'get'], ['get', 'get', 'build'], ...
+        // ['build', 'build', 'build']]
+        //
+        $methods = ['get', 'build'];
+        foreach ($methods as $method1) {
+            foreach ($methods as $method2) {
+                foreach ($methods as $method3) {
+                    $callSequences[] = [$method1, $method2, $method3];
+                }
+            }
+        }
+
+        foreach ($configs as $config) {
+            $smTemplate = $this->createContainer($config);
+
+            // setup sharing, services are always shared
+            $names = array_fill_keys(array_keys($config['services']), true);
+
+            // initialize the other keys with shared_by_default
+            // and merge them
+            $names = array_merge(array_fill_keys(array_keys(array_merge(
+                $config['factories'],
+                $config['invokables'],
+                $config['aliases'],
+                $config['delegators']
+            )), $config['shared_by_default'] ?? true), $names);
+
+            // add the key resolved by the abstract factory
+            $names['foo'] = $config['shared_by_default'] ?? true;
+
+            // adjust shared setting for individual keys from
+            // $shared array if present
+            if (! empty($config['shared'])) {
+                foreach ($config['shared'] as $name => $shared) {
+                    $names[$name] = $shared;
+                }
+            }
+
+            foreach ($names as $name => $shared) {
+                foreach ($callSequences as $callSequence) {
+                    $sm = clone $smTemplate;
+                    $tests[] = [$smTemplate, $name, $callSequence, $shared];
+                }
+            }
+        }
+        return $tests;
     }
 }

--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -21,17 +21,10 @@ use Zend\ServiceManager\Initializer\InitializerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZendTest\ServiceManager\TestAsset\CallTimesAbstractFactory;
 use ZendTest\ServiceManager\TestAsset\FailingAbstractFactory;
-use ZendTest\ServiceManager\TestAsset\FailingExceptionWithStringAsCodeFactory;
 use ZendTest\ServiceManager\TestAsset\FailingFactory;
+use ZendTest\ServiceManager\TestAsset\FailingExceptionWithStringAsCodeFactory;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\SimpleAbstractFactory;
-
-use function call_user_func_array;
-use function restore_error_handler;
-use function set_error_handler;
-use ZendTest\ServiceManager\TestAsset\SampleFactory;
-use ZendTest\ServiceManager\TestAsset\AbstractFactoryFoo;
-use ZendTest\ServiceManager\TestAsset\PassthroughDelegatorFactory;
 
 trait CommonServiceLocatorBehaviorsTrait
 {
@@ -53,7 +46,7 @@ trait CommonServiceLocatorBehaviorsTrait
         $object1 = $serviceManager->get(stdClass::class);
         $object2 = $serviceManager->get(stdClass::class);
 
-        self::assertSame($object1, $object2);
+        $this->assertSame($object1, $object2);
     }
 
     public function testCanDisableSharedByDefault()
@@ -68,7 +61,7 @@ trait CommonServiceLocatorBehaviorsTrait
         $object1 = $serviceManager->get(stdClass::class);
         $object2 = $serviceManager->get(stdClass::class);
 
-        self::assertNotSame($object1, $object2);
+        $this->assertNotSame($object1, $object2);
     }
 
     public function testCanDisableSharedForSingleService()
@@ -85,7 +78,7 @@ trait CommonServiceLocatorBehaviorsTrait
         $object1 = $serviceManager->get(stdClass::class);
         $object2 = $serviceManager->get(stdClass::class);
 
-        self::assertNotSame($object1, $object2);
+        $this->assertNotSame($object1, $object2);
     }
 
     public function testCanEnableSharedForSingleService()
@@ -103,7 +96,7 @@ trait CommonServiceLocatorBehaviorsTrait
         $object1 = $serviceManager->get(stdClass::class);
         $object2 = $serviceManager->get(stdClass::class);
 
-        self::assertSame($object1, $object2);
+        $this->assertSame($object1, $object2);
     }
 
     public function testCanBuildObjectWithInvokableFactory()
@@ -116,8 +109,8 @@ trait CommonServiceLocatorBehaviorsTrait
 
         $object = $serviceManager->build(InvokableObject::class, ['foo' => 'bar']);
 
-        self::assertInstanceOf(InvokableObject::class, $object);
-        self::assertEquals(['foo' => 'bar'], $object->options);
+        $this->assertInstanceOf(InvokableObject::class, $object);
+        $this->assertEquals(['foo' => 'bar'], $object->options);
     }
 
     public function testCanCreateObjectWithClosureFactory()
@@ -125,14 +118,14 @@ trait CommonServiceLocatorBehaviorsTrait
         $serviceManager = $this->createContainer([
             'factories' => [
                 stdClass::class => function (ServiceLocatorInterface $serviceLocator, $className) {
-                    self::assertEquals(stdClass::class, $className);
+                    $this->assertEquals(stdClass::class, $className);
                     return new stdClass();
                 }
             ]
         ]);
 
         $object = $serviceManager->get(stdClass::class);
-        self::assertInstanceOf(stdClass::class, $object);
+        $this->assertInstanceOf(stdClass::class, $object);
     }
 
     public function testCanCreateServiceWithAbstractFactory()
@@ -143,7 +136,7 @@ trait CommonServiceLocatorBehaviorsTrait
             ]
         ]);
 
-        self::assertInstanceOf(DateTime::class, $serviceManager->get(DateTime::class));
+        $this->assertInstanceOf(DateTime::class, $serviceManager->get(DateTime::class));
     }
 
     public function testAllowsMultipleInstancesOfTheSameAbstractFactory()
@@ -163,7 +156,7 @@ trait CommonServiceLocatorBehaviorsTrait
         $serviceManager->addAbstractFactory($obj2);
         $serviceManager->has(stdClass::class);
 
-        self::assertEquals(2, CallTimesAbstractFactory::getCallTimes());
+        $this->assertEquals(2, CallTimesAbstractFactory::getCallTimes());
     }
 
     public function testWillReUseAnExistingNamedAbstractFactoryInstance()
@@ -179,7 +172,7 @@ trait CommonServiceLocatorBehaviorsTrait
         $serviceManager->addAbstractFactory(CallTimesAbstractFactory::class);
         $serviceManager->has(stdClass::class);
 
-        self::assertEquals(1, CallTimesAbstractFactory::getCallTimes());
+        $this->assertEquals(1, CallTimesAbstractFactory::getCallTimes());
     }
 
     public function testCanCreateServiceWithAlias()
@@ -196,9 +189,9 @@ trait CommonServiceLocatorBehaviorsTrait
 
         $object = $serviceManager->get('bar');
 
-        self::assertInstanceOf(InvokableObject::class, $object);
-        self::assertTrue($serviceManager->has('bar'));
-        self::assertFalse($serviceManager->has('baz'));
+        $this->assertInstanceOf(InvokableObject::class, $object);
+        $this->assertTrue($serviceManager->has('bar'));
+        $this->assertFalse($serviceManager->has('baz'));
     }
 
     public function testCheckingServiceExistenceWithChecksAgainstAbstractFactories()
@@ -212,8 +205,8 @@ trait CommonServiceLocatorBehaviorsTrait
             ]
         ]);
 
-        self::assertTrue($serviceManager->has(stdClass::class));
-        self::assertTrue($serviceManager->has(DateTime::class));
+        $this->assertTrue($serviceManager->has(stdClass::class));
+        $this->assertTrue($serviceManager->has(DateTime::class));
     }
 
     public function testBuildNeverSharesInstances()
@@ -230,7 +223,7 @@ trait CommonServiceLocatorBehaviorsTrait
         $object1 = $serviceManager->build(stdClass::class);
         $object2 = $serviceManager->build(stdClass::class, ['foo' => 'bar']);
 
-        self::assertNotSame($object1, $object2);
+        $this->assertNotSame($object1, $object2);
     }
 
     public function testInitializersAreRunAfterCreation()
@@ -291,8 +284,8 @@ trait CommonServiceLocatorBehaviorsTrait
             ]
         ]);
 
-        self::assertTrue($serviceManager->has(DateTime::class));
-        self::assertFalse($serviceManager->has(stdClass::class));
+        $this->assertTrue($serviceManager->has(DateTime::class));
+        $this->assertFalse($serviceManager->has(stdClass::class));
 
         $newServiceManager = $serviceManager->configure([
             'factories' => [
@@ -300,10 +293,10 @@ trait CommonServiceLocatorBehaviorsTrait
             ]
         ]);
 
-        self::assertSame($serviceManager, $newServiceManager);
+        $this->assertSame($serviceManager, $newServiceManager);
 
-        self::assertTrue($newServiceManager->has(DateTime::class));
-        self::assertTrue($newServiceManager->has(stdClass::class));
+        $this->assertTrue($newServiceManager->has(DateTime::class));
+        $this->assertTrue($newServiceManager->has(stdClass::class));
     }
 
     public function testConfigureCanOverridePreviousSettings()
@@ -325,7 +318,7 @@ trait CommonServiceLocatorBehaviorsTrait
             ]
         ]);
 
-        self::assertSame($serviceManager, $newServiceManager);
+        $this->assertSame($serviceManager, $newServiceManager);
 
         $firstFactory->expects($this->never())->method('__invoke');
         $secondFactory->expects($this->once())->method('__invoke');
@@ -343,7 +336,7 @@ trait CommonServiceLocatorBehaviorsTrait
                 stdClass::class => InvokableFactory::class,
             ],
         ]);
-        self::assertFalse($serviceManager->has('Some\Made\Up\Entry'));
+        $this->assertFalse($serviceManager->has('Some\Made\Up\Entry'));
     }
 
     /**
@@ -356,7 +349,7 @@ trait CommonServiceLocatorBehaviorsTrait
                 stdClass::class => new stdClass,
             ],
         ]);
-        self::assertTrue($serviceManager->has(stdClass::class));
+        $this->assertTrue($serviceManager->has(stdClass::class));
     }
 
     /**
@@ -369,7 +362,7 @@ trait CommonServiceLocatorBehaviorsTrait
                 stdClass::class => InvokableFactory::class,
             ],
         ]);
-        self::assertTrue($serviceManager->has(stdClass::class));
+        $this->assertTrue($serviceManager->has(stdClass::class));
     }
 
     public function abstractFactories()
@@ -392,7 +385,7 @@ trait CommonServiceLocatorBehaviorsTrait
             ],
         ]);
 
-        self::assertSame($expected, $serviceManager->has(DateTime::class));
+        $this->assertSame($expected, $serviceManager->has(DateTime::class));
     }
 
     /**
@@ -438,40 +431,40 @@ trait CommonServiceLocatorBehaviorsTrait
         ]);
 
         $dateTime = $serviceManager->get(DateTime::class);
-        self::assertInstanceOf(DateTime::class, $dateTime, 'DateTime service did not resolve as expected');
+        $this->assertInstanceOf(DateTime::class, $dateTime, 'DateTime service did not resolve as expected');
         $notShared = $serviceManager->get(DateTime::class);
-        self::assertInstanceOf(DateTime::class, $notShared, 'DateTime service did not re-resolve as expected');
-        self::assertNotSame(
+        $this->assertInstanceOf(DateTime::class, $notShared, 'DateTime service did not re-resolve as expected');
+        $this->assertNotSame(
             $dateTime,
             $notShared,
             'Expected unshared instances for DateTime service but received shared instances'
         );
 
         $config = $serviceManager->get('config');
-        self::assertInternalType('array', $config, 'Config service did not resolve as expected');
-        self::assertSame(
+        $this->assertInternalType('array', $config, 'Config service did not resolve as expected');
+        $this->assertSame(
             $config,
             $serviceManager->get('config'),
             'Config service resolved as unshared instead of shared'
         );
 
         $stdClass = $serviceManager->get(stdClass::class);
-        self::assertInstanceOf(stdClass::class, $stdClass, 'stdClass service did not resolve as expected');
-        self::assertSame(
+        $this->assertInstanceOf(stdClass::class, $stdClass, 'stdClass service did not resolve as expected');
+        $this->assertSame(
             $stdClass,
             $serviceManager->get(stdClass::class),
             'stdClass service should be shared, but resolved as unshared'
         );
-        self::assertTrue(
+        $this->assertTrue(
             isset($stdClass->foo),
             'Expected delegator to inject "foo" property in stdClass service, but it was not'
         );
-        self::assertEquals('bar', $stdClass->foo, 'stdClass "foo" property was not injected correctly');
-        self::assertTrue(
+        $this->assertEquals('bar', $stdClass->foo, 'stdClass "foo" property was not injected correctly');
+        $this->assertTrue(
             isset($stdClass->bar),
             'Expected initializer to inject "bar" property in stdClass service, but it was not'
         );
-        self::assertEquals('baz', $stdClass->bar, 'stdClass "bar" property was not injected correctly');
+        $this->assertEquals('baz', $stdClass->bar, 'stdClass "bar" property was not injected correctly');
     }
 
     /**
@@ -486,7 +479,7 @@ trait CommonServiceLocatorBehaviorsTrait
         ]);
 
         $dateTime = $serviceManager->get(DateTime::class);
-        self::assertInstanceOf(DateTime::class, $dateTime);
+        $this->assertInstanceOf(DateTime::class, $dateTime);
     }
 
     public function invalidFactories()
@@ -521,7 +514,7 @@ trait CommonServiceLocatorBehaviorsTrait
     ) {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($contains);
-        $this->createContainer([
+        $serviceManager = $this->createContainer([
             'abstract_factories' => [
                 $factory,
             ],
@@ -540,15 +533,15 @@ trait CommonServiceLocatorBehaviorsTrait
         ]);
 
         $instance = $serviceManager->get(stdClass::class);
-        self::assertInstanceOf(stdClass::class, $instance);
-        self::assertTrue(isset($instance->foo), '"foo" property was not injected by initializer');
-        self::assertEquals('bar', $instance->foo, '"foo" property was not properly injected');
+        $this->assertInstanceOf(stdClass::class, $instance);
+        $this->assertTrue(isset($instance->foo), '"foo" property was not injected by initializer');
+        $this->assertEquals('bar', $instance->foo, '"foo" property was not properly injected');
     }
 
     public function invalidInitializers()
     {
         $factories = $this->invalidFactories();
-        $factories['non-class-string'] = ['non-callable-string', 'callable or an instance of'];
+        $factories['non-class-string'] = ['non-callable-string', 'valid function name, class name'];
         return $factories;
     }
 
@@ -562,7 +555,7 @@ trait CommonServiceLocatorBehaviorsTrait
     ) {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($contains);
-        $this->createContainer([
+        $serviceManager = $this->createContainer([
             'initializers' => [
                 $initializer,
             ],
@@ -596,6 +589,9 @@ trait CommonServiceLocatorBehaviorsTrait
         $delegator,
         $contains = 'non-callable delegator'
     ) {
+        $config = [
+            'option' => 'OPTIONED',
+        ];
         $serviceManager = $this->createContainer([
             'factories' => [
                 stdClass::class => InvokableFactory::class,
@@ -630,9 +626,9 @@ trait CommonServiceLocatorBehaviorsTrait
 
         $foo = $container->get('foo');
         $bar = $container->get('bar');
-        self::assertInstanceOf(stdClass::class, $foo);
-        self::assertInstanceOf(stdClass::class, $bar);
-        self::assertSame($foo, $bar);
+        $this->assertInstanceOf(stdClass::class, $foo);
+        $this->assertInstanceOf(stdClass::class, $bar);
+        $this->assertSame($foo, $bar);
     }
 
     /**
@@ -643,10 +639,9 @@ trait CommonServiceLocatorBehaviorsTrait
     {
         $container = $this->createContainer();
         $container->setInvokableClass('foo', stdClass::class);
-        self::assertTrue($container->has('foo'));
-        self::assertTrue($container->has(stdClass::class));
+        $this->assertTrue($container->has('foo'));
         $foo = $container->get('foo');
-        self::assertInstanceOf(stdClass::class, $foo);
+        $this->assertInstanceOf(stdClass::class, $foo);
     }
 
     /**
@@ -661,9 +656,9 @@ trait CommonServiceLocatorBehaviorsTrait
         $container->setFactory('foo', function () use ($instance) {
             return $instance;
         });
-        self::assertTrue($container->has('foo'));
+        $this->assertTrue($container->has('foo'));
         $foo = $container->get('foo');
-        self::assertSame($instance, $foo);
+        $this->assertSame($instance, $foo);
     }
 
     /**
@@ -677,9 +672,9 @@ trait CommonServiceLocatorBehaviorsTrait
         $r = new ReflectionProperty($container, 'lazyServices');
         $r->setAccessible(true);
         $lazyServices = $r->getValue($container);
-        self::assertArrayHasKey('class_map', $lazyServices);
-        self::assertArrayHasKey('foo', $lazyServices['class_map']);
-        self::assertEquals(__CLASS__, $lazyServices['class_map']['foo']);
+        $this->assertArrayHasKey('class_map', $lazyServices);
+        $this->assertArrayHasKey('foo', $lazyServices['class_map']);
+        $this->assertEquals(__CLASS__, $lazyServices['class_map']['foo']);
     }
 
     /**
@@ -691,9 +686,9 @@ trait CommonServiceLocatorBehaviorsTrait
         $container = $this->createContainer();
         $container->addAbstractFactory(TestAsset\SimpleAbstractFactory::class);
         // @todo Remove "true" flag once #49 is merged
-        self::assertTrue($container->has(stdClass::class, true));
+        $this->assertTrue($container->has(stdClass::class, true));
         $instance = $container->get(stdClass::class);
-        self::assertInstanceOf(stdClass::class, $instance);
+        $this->assertInstanceOf(stdClass::class, $instance);
     }
 
     /**
@@ -716,8 +711,8 @@ trait CommonServiceLocatorBehaviorsTrait
         });
 
         $foo = $container->get('foo');
-        self::assertInstanceOf(stdClass::class, $foo);
-        self::assertAttributeEquals('foo', 'name', $foo);
+        $this->assertInstanceOf(stdClass::class, $foo);
+        $this->assertAttributeEquals('foo', 'name', $foo);
     }
 
     /**
@@ -742,8 +737,8 @@ trait CommonServiceLocatorBehaviorsTrait
         });
 
         $foo = $container->get('foo');
-        self::assertInstanceOf(stdClass::class, $foo);
-        self::assertAttributeEquals(stdClass::class, 'name', $foo);
+        $this->assertInstanceOf(stdClass::class, $foo);
+        $this->assertAttributeEquals(stdClass::class, 'name', $foo);
     }
 
     /**
@@ -754,7 +749,7 @@ trait CommonServiceLocatorBehaviorsTrait
     {
         $container = $this->createContainer();
         $container->setService('foo', $this);
-        self::assertSame($this, $container->get('foo'));
+        $this->assertSame($this, $container->get('foo'));
     }
 
     /**
@@ -773,7 +768,7 @@ trait CommonServiceLocatorBehaviorsTrait
         $container->setShared('foo', false);
         $first  = $container->get('foo');
         $second = $container->get('foo');
-        self::assertNotSame($first, $second);
+        $this->assertNotSame($first, $second);
     }
 
     public function methodsAffectedByOverrideSettings()
@@ -817,7 +812,7 @@ trait CommonServiceLocatorBehaviorsTrait
     public function testAllowOverrideFlagIsFalseByDefault()
     {
         $container = $this->createContainer();
-        self::assertFalse($container->getAllowOverride());
+        $this->assertFalse($container->getAllowOverride());
         return $container;
     }
 
@@ -828,7 +823,7 @@ trait CommonServiceLocatorBehaviorsTrait
     public function testAllowOverrideFlagIsMutable($container)
     {
         $container->setAllowOverride(true);
-        self::assertTrue($container->getAllowOverride());
+        $this->assertTrue($container->getAllowOverride());
     }
 
     /**
@@ -838,9 +833,9 @@ trait CommonServiceLocatorBehaviorsTrait
     {
         $container = $this->createContainer();
         set_error_handler(function ($errno, $errstr) {
-            self::assertEquals(E_USER_DEPRECATED, $errno);
+            $this->assertEquals(E_USER_DEPRECATED, $errno);
         }, E_USER_DEPRECATED);
-        self::assertSame($this->creationContext, $container->getServiceLocator());
+        $this->assertSame($this->creationContext, $container->getServiceLocator());
         restore_error_handler();
     }
 
@@ -857,179 +852,5 @@ trait CommonServiceLocatorBehaviorsTrait
                 'b' => 'a',
             ],
         ]);
-    }
-
-    public function testMinimalCyclicAliasDefinitionShouldThrow()
-    {
-        $sm = $this->createContainer([]);
-
-        $this->expectException(CyclicAliasException::class);
-        $sm->setAlias('alias', 'alias');
-    }
-
-    public function testCoverageDepthFirstTaggingOnRecursiveAliasDefinitions()
-    {
-        $sm = $this->createContainer([
-            'factories' => [
-                stdClass::class => InvokableFactory::class,
-            ],
-            'aliases' => [
-                'alias1' => 'alias2',
-                'alias2' => 'alias3',
-                'alias3' => stdClass::class,
-            ],
-        ]);
-        $this->assertSame($sm->get('alias1'), $sm->get('alias2'));
-        $this->assertSame($sm->get(stdClass::class), $sm->get('alias1'));
-    }
-
-    /**
-     * The ServiceManager can change internal state on calls to get,
-     * build or has, latter not currently. Possible state changes
-     * are caching a factory, registering a service produced by
-     * a factory, ...
-     *
-     * This tests performs three consecutive calls to build/get for
-     * each registered service to push the service manager through
-     * all internal states, thereby verifying that build/get/has
-     * remain stable through the internal states.
-     *
-     * @dataProvider provideConsistencyOverInternalStatesTests
-     *
-     * @param ContainerInterface $smTemplate
-     * @param string $name
-     * @param array[] string $test
-     */
-    public function testConsistencyOverInternalStates($smTemplate, $name, $test, $shared)
-    {
-        $sm = clone $smTemplate;
-        $object['get'] = [];
-        $object['build'] = [];
-
-        // call get()/build() and store the retrieved
-        // objects in $object['get'] or $object['build']
-        // respectively
-        foreach ($test as $method) {
-            $obj = $sm->$method($name);
-            $object[$shared ? $method : 'build'][] = $obj;
-            $this->assertNotNull($obj);
-            $this->assertTrue($sm->has($name));
-        }
-
-        // compares the first to the first also, but ok
-        foreach ($object['get'] as $sharedObj) {
-            $this->assertSame($object['get'][0], $sharedObj);
-        }
-        // objects from object['build'] have to be different
-        // from all other objects
-        foreach ($object['build'] as $idx1 => $nonSharedObj1) {
-            $this->assertNotContains($nonSharedObj1, $object['get']);
-            foreach ($object['build'] as $idx2 => $nonSharedObj2) {
-                if ($idx1 !== $idx2) {
-                    $this->assertNotSame($nonSharedObj1, $nonSharedObj2);
-                }
-            }
-        }
-    }
-
-    /**
-     * Data provider
-     *
-     * @see testConsistencyOverInternalStates above
-     *
-     * @param ContainerInterface $smTemplate
-     * @param string $name
-     * @param string[] $test
-     */
-    public function provideConsistencyOverInternalStatesTests()
-    {
-        $config1 = [
-            'factories' => [
-                // to allow build('service')
-                'service' => function ($container, $requestedName, array $options = null) {
-                    return new stdClass();
-                },
-                'factory' => SampleFactory::class,
-                'delegator' => SampleFactory::class,
-             ],
-             'delegators' => [
-                 'delegator' => [
-                     PassthroughDelegatorFactory::class
-                 ],
-             ],
-            'invokables' => [
-                'invokable' => InvokableObject::class,
-            ],
-            'services' => [
-                'service' => new stdClass(),
-            ],
-             'aliases' => [
-                'serviceAlias'          => 'service',
-                'invokableAlias'        => 'invokable',
-                'factoryAlias'          => 'factory',
-                'abstractFactoryAlias'  => 'foo',
-                'delegatorAlias'        => 'delegator',
-             ],
-            'abstract_factories' => [
-                AbstractFactoryFoo::class
-            ]
-        ];
-        $config2 = $config1;
-        $config2['shared_by_default'] = false;
-
-        $configs = [ $config1, $config2 ];
-
-        foreach ($configs as $config) {
-            $smTemplates[] = $this->createContainer($config);
-        }
-
-        // produce all 3-tuples of 'build' and 'get', i.e.
-        //
-        // [['get', 'get', 'get'], ['get', 'get', 'build'], ...
-        // ['build', 'build', 'build']]
-        //
-        $methods = ['get', 'build'];
-        foreach ($methods as $method1) {
-            foreach ($methods as $method2) {
-                foreach ($methods as $method3) {
-                    $callSequences[] = [$method1, $method2, $method3];
-                }
-            }
-        }
-
-        foreach ($configs as $config) {
-            $smTemplate = $this->createContainer($config);
-
-            // setup sharing, services are always shared
-            $names = array_fill_keys(array_keys($config['services']), true);
-
-            // initialize the other keys with shared_by_default
-            // and merge them
-            $names = array_merge(array_fill_keys(array_keys(array_merge(
-                $config['factories'],
-                $config['invokables'],
-                $config['aliases'],
-                $config['delegators']
-            )), $config['shared_by_default'] ?? true), $names);
-
-            // add the key resolved by the abstract factory
-            $names['foo'] = $config['shared_by_default'] ?? true;
-
-            // adjust shared setting for individual keys from
-            // $shared array if present
-            if (! empty($config['shared'])) {
-                foreach ($config['shared'] as $name => $shared) {
-                    $names[$name] = $shared;
-                }
-            }
-
-            foreach ($names as $name => $shared) {
-                foreach ($callSequences as $callSequence) {
-                    $sm = clone $smTemplate;
-                    $tests[] = [$smTemplate, $name, $callSequence, $shared];
-                }
-            }
-        }
-        return $tests;
     }
 }

--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -562,9 +562,6 @@ trait CommonServiceLocatorBehaviorsTrait
         ]);
     }
 
-    /**
-     * @covers \Zend\ServiceManager\ServiceManager::getFactory
-     */
     public function testGetRaisesExceptionWhenNoFactoryIsResolved()
     {
         $serviceManager = $this->createContainer();

--- a/test/Exception/CyclicAliasExceptionTest.php
+++ b/test/Exception/CyclicAliasExceptionTest.php
@@ -26,7 +26,6 @@ class CyclicAliasExceptionTest extends TestCase
     public function testFromCyclicAlias($alias, array $aliases, $expectedMessage)
     {
         $exception = CyclicAliasException::fromCyclicAlias($alias, $aliases);
-
         self::assertInstanceOf(CyclicAliasException::class, $exception);
         self::assertSame($expectedMessage, $exception->getMessage());
     }

--- a/test/Exception/InvalidArgumentExceptionTest.php
+++ b/test/Exception/InvalidArgumentExceptionTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @link      https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\Exception;
+
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Zend\ServiceManager\Initializer\InitializerInterface;
+use Zend\ServiceManager\Exception\InvalidArgumentException;
+use Zend\ServiceManager\AbstractFactoryInterface;
+
+/**
+ * @covers \Zend\ServiceManager\Exception\InvalidArgumentException
+ */
+class InvalidArgumentExceptionTest extends TestCase
+{
+
+    public function testFromInvalidInitializer()
+    {
+        $exception = InvalidArgumentException::fromInvalidInitializer(new stdClass());
+        $this->assertInstanceOf(InvalidArgumentException::class, $exception);
+        $this->assertSame(
+            'An invalid initializer was registered. Expected a valid function name, '
+            . 'class name, a callable or an instance of "'. InitializerInterface::class
+            . '", but "stdClass" was received.'
+            , $exception->getMessage());
+
+        // because the named constructor does not check if classes or functions exist
+        // or the argument is_callable or an instance of InitializerInterface
+        // we are done here
+    }
+
+    public function testFromInvalidAbstractFactory()
+    {
+        $exception = InvalidArgumentException::fromInvalidAbstractFactory(new stdClass());
+        $this->assertInstanceOf(InvalidArgumentException::class, $exception);
+        $this->assertSame('An invalid abstract factory was registered. Expected an instance of or a valid'
+            . ' class name resolving to an implementation of "'. AbstractFactoryInterface::class
+            . '", but "stdClass" was received.', $exception->getMessage());
+
+        // because the named constructor does not check if classes or functions exist
+        // or the argument is_callable or an instance of InitializerInterface
+        // we are done here
+    }
+}

--- a/test/Exception/InvalidArgumentExceptionTest.php
+++ b/test/Exception/InvalidArgumentExceptionTest.php
@@ -26,8 +26,9 @@ class InvalidArgumentExceptionTest extends TestCase
         $this->assertSame(
             'An invalid initializer was registered. Expected a valid function name, '
             . 'class name, a callable or an instance of "'. InitializerInterface::class
-            . '", but "stdClass" was received.'
-            , $exception->getMessage());
+            . '", but "stdClass" was received.',
+            $exception->getMessage()
+        );
 
         // because the named constructor does not check if classes or functions exist
         // or the argument is_callable or an instance of InitializerInterface

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -289,7 +289,6 @@ class ServiceManagerTest extends TestCase
         ->with($this->anything(), $this->equalTo('ServiceName'))
         ->willReturn(true);
         $this->assertTrue($serviceManager->has('Alias'));
-        
     }
 
     public static function sampleFactory()

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -306,28 +306,4 @@ class ServiceManagerTest extends TestCase
         $serviceManager = new SimpleServiceManager($config);
         $this->assertEquals(stdClass::class, get_class($serviceManager->get(stdClass::class)));
     }
-
-//     public function testMinimalCyclicAliasDefinitionShouldThrow()
-//     {
-//         $sm = new ServiceManager();
-
-//         $this->expectException(CyclicAliasException::class);
-//         $sm->setAlias('alias', 'alias');
-//     }
-
-//     public function testCoverageDepthFirstTaggingOnRecursiveAliasDefinitions()
-//     {
-//         $sm = new ServiceManager([
-//             'factories' => [
-//                 stdClass::class => InvokableFactory::class,
-//             ],
-//             'aliases' => [
-//                 'alias1' => 'alias2',
-//                 'alias2' => 'alias3',
-//                 'alias3' => stdClass::class,
-//             ],
-//         ]);
-//         $this->assertSame($sm->get('alias1'), $sm->get('alias2'));
-//         $this->assertSame($sm->get(stdClass::class), $sm->get('alias1'));
-//     }
 }

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -17,7 +17,6 @@ use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\ServiceManager\ServiceManager;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\SimpleServiceManager;
-use Zend\ServiceManager\Exception\CyclicAliasException;
 use PHPUnit\Framework\MockObject\Invokable;
 
 /**

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -253,10 +253,10 @@ class ServiceManagerTest extends TestCase
             ],
         ]);
         $abstractFactory
-        ->expects($this->once())
-        ->method('canCreate')
-        ->with($this->anything(), $this->equalTo('ServiceName'))
-        ->willReturn(true);
+            ->expects($this->once())
+            ->method('canCreate')
+            ->with($this->anything(), $this->equalTo('ServiceName'))
+            ->willReturn(true);
         $this->assertTrue($serviceManager->has('Alias'));
     }
 

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -155,40 +155,6 @@ class ServiceManagerTest extends TestCase
         self::assertEquals($shouldBeSameInstance, $a === $b);
     }
 
-    public function testMapsOneToOneInvokablesAsInvokableFactoriesInternally()
-    {
-        $config = [
-            'invokables' => [
-                InvokableObject::class => InvokableObject::class,
-            ],
-        ];
-
-        $serviceManager = new ServiceManager($config);
-        self::assertAttributeSame([
-            InvokableObject::class => InvokableFactory::class,
-        ], 'factories', $serviceManager, 'Invokable object factory not found');
-    }
-
-    public function testMapsNonSymmetricInvokablesAsAliasPlusInvokableFactory()
-    {
-        $config = [
-            'invokables' => [
-                'Invokable' => InvokableObject::class,
-            ],
-        ];
-
-        $serviceManager = new ServiceManager($config);
-        self::assertAttributeSame([
-            'Invokable' => InvokableObject::class,
-        ], 'aliases', $serviceManager, 'Alias not found for non-symmetric invokable');
-        self::assertAttributeSame([
-            InvokableObject::class => InvokableFactory::class,
-        ], 'factories', $serviceManager, 'Factory not found for non-symmetric invokable target');
-    }
-
-    /**
-     * @depends testMapsNonSymmetricInvokablesAsAliasPlusInvokableFactory
-     */
     public function testSharedServicesReferencingInvokableAliasShouldBeHonored()
     {
         $config = [

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -276,7 +276,17 @@ class ServiceManagerTest extends TestCase
         $this->assertEquals(stdClass::class, get_class($serviceManager->get(stdClass::class)));
     }
 
-    public function testMemberBasedConfigurationGetsApplied()
+    public function testMemberBasedAliasConfugrationGetsApplied()
+    {
+        $sm = new PreconfiguredServiceManager();
+
+        // will be true if $aliases array is properly setup and
+        // simple alias resolution works
+        $this->assertTrue($sm->has('alias2'));
+        $this->assertInstanceOf(stdClass::class, $sm->get('alias2'));
+    }
+
+    public function testMemberBasedRecursiveAliasConfugrationGetsApplied()
     {
         $sm = new PreconfiguredServiceManager();
 
@@ -284,43 +294,64 @@ class ServiceManagerTest extends TestCase
         // recursive alias resolution works
         $this->assertTrue($sm->has('alias1'));
         $this->assertInstanceOf(stdClass::class, $sm->get('alias1'));
+    }
 
-        // will be true if $aliases array is properly setup and
-        // simple alias resolution works
-        $this->assertTrue($sm->has('alias2'));
-        $this->assertInstanceOf(stdClass::class, $sm->get('alias2'));
+    public function testMemberBasedServiceConfugrationGetsApplied()
+    {
+        $sm = new PreconfiguredServiceManager();
 
         // will return true if $services array is properly setup
         $this->assertTrue($sm->has('service'));
         $this->assertInstanceOf(stdClass::class, $sm->get('service'));
+    }
+
+    public function testMemberBasedDelegatorConfugrationGetsApplied()
+    {
+        $sm = new PreconfiguredServiceManager();
 
         // will be true if factory array is properly setup
         $this->assertTrue($sm->has('delegator'));
         $this->assertInstanceOf(InvokableObject::class, $sm->get('delegator'));
 
         // will be true if initializer is present
-        $this->assertTrue($sm->get('delegator')->initializerPresent);
+        $this->assertObjectHasAttribute('initializerPresent', $sm->get('delegator'));
+    }
+
+    public function testMemberBasedFactoryConfugrationGetsApplied()
+    {
+        $sm = new PreconfiguredServiceManager();
 
         // will be true if factory array is properly setup
         $this->assertTrue($sm->has('factory'));
         $this->assertInstanceOf(InvokableObject::class, $sm->get('factory'));
 
         // will be true if initializer is present
-        $this->assertTrue($sm->get('factory')->initializerPresent);
+        $this->assertObjectHasAttribute('initializerPresent', $sm->get('delegator'));
+    }
+
+    public function testMemberBasedInvokableConfigurationGetsApplied()
+    {
+        $sm = new PreconfiguredServiceManager();
 
         // will succeed if invokable is properly set up
         $this->assertTrue($sm->has('invokable'));
         $this->assertInstanceOf(stdClass::class, $sm->get('invokable'));
 
         // will be true if initializer is present
-        $this->assertTrue($sm->get('invokable')->initializerPresent);
+        $this->assertObjectHasAttribute('initializerPresent', $sm->get('delegator'));
+    }
+
+    public function testMemberBasedAbstractFactoryConfigurationGetsApplied()
+    {
+        $sm = new PreconfiguredServiceManager();
+
 
         // will succeed if abstract factory is available
         $this->assertTrue($sm->has('foo'));
         $this->assertInstanceOf(Foo::class, $sm->get('foo'));
 
         // will be true if initializer is present
-        $this->assertTrue($sm->get('foo')->initializerPresent);
+        $this->assertObjectHasAttribute('initializerPresent', $sm->get('delegator'));
     }
 
     public function testInvokablesShouldNotOverrideFactoriesAndDelegators()

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -16,7 +16,9 @@ use Zend\ServiceManager\Factory\AbstractFactoryInterface;
 use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\ServiceManager\ServiceManager;
+use ZendTest\ServiceManager\TestAsset\Foo;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
+use ZendTest\ServiceManager\TestAsset\PreconfiguredServiceManager;
 use ZendTest\ServiceManager\TestAsset\SampleFactory;
 use ZendTest\ServiceManager\TestAsset\SimpleServiceManager;
 use ZendTest\ServiceManager\TestAsset\TaggingDelegatorFactory;
@@ -272,6 +274,53 @@ class ServiceManagerTest extends TestCase
         ];
         $serviceManager = new SimpleServiceManager($config);
         $this->assertEquals(stdClass::class, get_class($serviceManager->get(stdClass::class)));
+    }
+
+    public function testMemberBasedConfigurationGetsApplied()
+    {
+        $sm = new PreconfiguredServiceManager();
+
+        // will be true if $aliases array is properly setup and
+        // recursive alias resolution works
+        $this->assertTrue($sm->has('alias1'));
+        $this->assertInstanceOf(stdClass::class, $sm->get('alias1'));
+
+        // will be true if $aliases array is properly setup and
+        // simple alias resolution works
+        $this->assertTrue($sm->has('alias2'));
+        $this->assertInstanceOf(stdClass::class, $sm->get('alias2'));
+
+        // will return true if $services array is properly setup
+        $this->assertTrue($sm->has('service'));
+        $this->assertInstanceOf(stdClass::class, $sm->get('service'));
+
+        // will be true if factory array is properly setup
+        $this->assertTrue($sm->has('delegator'));
+        $this->assertInstanceOf(InvokableObject::class, $sm->get('delegator'));
+
+        // will be true if initializer is present
+        $this->assertTrue($sm->get('delegator')->initializerPresent);
+
+        // will be true if factory array is properly setup
+        $this->assertTrue($sm->has('factory'));
+        $this->assertInstanceOf(InvokableObject::class, $sm->get('factory'));
+
+        // will be true if initializer is present
+        $this->assertTrue($sm->get('factory')->initializerPresent);
+
+        // will succeed if invokable is properly set up
+        $this->assertTrue($sm->has('invokable'));
+        $this->assertInstanceOf(stdClass::class, $sm->get('invokable'));
+
+        // will be true if initializer is present
+        $this->assertTrue($sm->get('invokable')->initializerPresent);
+
+        // will succeed if abstract factory is available
+        $this->assertTrue($sm->has('foo'));
+        $this->assertInstanceOf(Foo::class, $sm->get('foo'));
+
+        // will be true if initializer is present
+        $this->assertTrue($sm->get('foo')->initializerPresent);
     }
 
     public function testInvokablesShouldNotOverrideFactoriesAndDelegators()

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -8,6 +8,7 @@
 namespace ZendTest\ServiceManager;
 
 use DateTime;
+use PHPUnit\Framework\MockObject\Invokable;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use stdClass;
@@ -16,9 +17,9 @@ use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\ServiceManager\ServiceManager;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
-use ZendTest\ServiceManager\TestAsset\SimpleServiceManager;
-use PHPUnit\Framework\MockObject\Invokable;
 use ZendTest\ServiceManager\TestAsset\SampleFactory;
+use ZendTest\ServiceManager\TestAsset\SimpleServiceManager;
+use ZendTest\ServiceManager\TestAsset\TaggingDelegatorFactory;
 
 /**
  * @covers \Zend\ServiceManager\ServiceManager

--- a/test/TestAsset/Foo.php
+++ b/test/TestAsset/Foo.php
@@ -10,9 +10,15 @@ namespace ZendTest\ServiceManager\TestAsset;
 class Foo
 {
     protected $options;
+    public $initializerPresent = false;
 
     public function __construct($options = null)
     {
         $this->options = $options;
+    }
+
+    public function assertInitializer()
+    {
+        $this->initializerPresent = true;
     }
 }

--- a/test/TestAsset/PassthroughDelegatorFactory.php
+++ b/test/TestAsset/PassthroughDelegatorFactory.php
@@ -16,8 +16,13 @@ class PassthroughDelegatorFactory implements DelegatorFactoryInterface
      * {@inheritDoc}
      * @see \Zend\ServiceManager\Factory\DelegatorFactoryInterface::__invoke()
      */
-    public function __invoke(\Interop\Container\ContainerInterface $container, $name, callable $callback, array $options = null)
-    {
+    public function __invoke(
+        \Interop\Container\ContainerInterface $container,
+        $name,
+        callable $callback,
+        array $options = null
+    ) {
+
         return call_user_func($callback);
     }
 }

--- a/test/TestAsset/PassthroughDelegatorFactory.php
+++ b/test/TestAsset/PassthroughDelegatorFactory.php
@@ -16,7 +16,7 @@ class PassthroughDelegatorFactory implements DelegatorFactoryInterface
      * {@inheritDoc}
      * @see \Zend\ServiceManager\Factory\DelegatorFactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $name, callable $callback, array $options = null)
+    public function __invoke(\Interop\Container\ContainerInterface $container, $name, callable $callback, array $options = null)
     {
         return call_user_func($callback);
     }

--- a/test/TestAsset/PreconfiguredServiceManager.php
+++ b/test/TestAsset/PreconfiguredServiceManager.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @link      https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use stdClass;
+use Zend\ServiceManager\ServiceManager;
+
+class PreconfiguredServiceManager extends ServiceManager
+{
+    protected $services = [];
+
+    protected $aliases = [
+        'alias1' => 'alias2',
+        'alias2' => 'service',
+    ];
+
+    protected $factories = [
+        'delegator' => SampleFactory::class,
+        'factory'   => SampleFactory::class,
+    ];
+
+    protected $delegators = [
+        'delegator' => [
+            PassthroughDelegatorFactory::class,
+        ],
+    ];
+
+    protected $invokables = [
+        'invokable' => stdClass::class,
+    ];
+
+    protected $initializers = [
+        TaggingInitializer::class,
+    ];
+
+    protected $abstractFactories = [
+        AbstractFactoryFoo::class,
+    ];
+
+    public function __construct(array $config = [])
+    {
+        $this->services = [
+            'service' => new stdClass(),
+        ];
+        parent::__construct($config);
+    }
+}

--- a/test/TestAsset/TaggingDelegatorFactory.php
+++ b/test/TestAsset/TaggingDelegatorFactory.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @link      https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\DelegatorFactoryInterface;
+
+class TaggingDelegatorFactory implements DelegatorFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     * @see \Zend\ServiceManager\Factory\DelegatorFactoryInterface::__invoke()
+     */
+    public function __invoke(
+        \Interop\Container\ContainerInterface $container,
+        $name,
+        callable $callback,
+        array $options = null
+    ) {
+        $object = call_user_func($callback);
+        $object->delegatorTag = true;
+        return $object;
+    }
+}

--- a/test/TestAsset/TaggingInitializer.php
+++ b/test/TestAsset/TaggingInitializer.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @link      https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Zend\ServiceManager\Initializer\InitializerInterface;
+
+class TaggingInitializer implements InitializerInterface
+{
+    /**
+     * {@inheritDoc}
+     * @see \Zend\ServiceManager\TaggingInitializer\InitializerInterface::__invoke()
+     */
+    public function __invoke(\Interop\Container\ContainerInterface $container, $instance)
+    {
+        $instance->initializerPresent = true;
+    }
+}


### PR DESCRIPTION
This PR initially delivered the rest of #221. As several bugs were unrevealed in the process I created according tests and fixes for master with #242.

This PR applies the same fixes to develop recognizing that #221 and #230 were already merged. The issuese fixed are in particular 

1. Preconfigured abstract factories are not resolved.
2. Preconfigured initializers are not resolved.
3. Preconfigured invokables are not resolved.
4. Invokables defined as name => InvokableClass can override delegators and factories.

A performance gain of more than 100% in FetchNewServiceManagerBench.php is a welcome side effect. 

Btw, I should have named this branch initially 'Rest-Of-#221'. 211 was wrong right from the beginning. :(