### PR TITLE
Performance optimize invokables (bug fix also)

### DIFF
--- a/benchmarks/BenchAsset/DelegatorFactoryFoo.php
+++ b/benchmarks/BenchAsset/DelegatorFactoryFoo.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendBench\ServiceManager\BenchAsset;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\DelegatorFactoryInterface;
+
+class DelegatorFactoryFoo implements DelegatorFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     * @see \Zend\ServiceManager\Factory\DelegatorFactoryInterface::__invoke()
+     */
+    public function __invoke(ContainerInterface $container, $name, callable $callback, array $options = null)
+    {
+        $foo = call_user_func($callback);
+        return $foo;
+    }
+}

--- a/benchmarks/BenchAsset/DelegatorFactoryFoo.php
+++ b/benchmarks/BenchAsset/DelegatorFactoryFoo.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 

--- a/benchmarks/BenchAsset/InitializerFoo.php
+++ b/benchmarks/BenchAsset/InitializerFoo.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendBench\ServiceManager\BenchAsset;
+
+use Zend\ServiceManager\Initializer\InitializerInterface;
+
+class InitializerFoo implements InitializerInterface
+{
+    protected $options;
+
+    /**
+     * {@inheritDoc}
+     * @see \Zend\ServiceManager\Initializer\InitializerInterface::__invoke()
+     */
+    public function __invoke(\Interop\Container\ContainerInterface $container, $instance)
+    {
+    }
+
+    public function __construct($options = null)
+    {
+        $this->options = $options;
+    }
+}

--- a/benchmarks/BenchAsset/InitializerFoo.php
+++ b/benchmarks/BenchAsset/InitializerFoo.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 

--- a/benchmarks/SetNewServicesBench.php
+++ b/benchmarks/SetNewServicesBench.php
@@ -52,12 +52,12 @@ class SetNewServicesBench
             $config['invokables']['invokable_$i'] = BenchAsset\Foo::class;
             $config['delegators']['delegator_$i'] = [ DelegatorFactoryFoo::class ];
         }
-        
+
         $this->initializer = new BenchAsset\InitializerFoo();
         $this->abstractFactory = new BenchAsset\AbstractFactoryFoo();
         $this->sm = new ServiceManager($config);
     }
-        
+
 
     public function benchSetService()
     {
@@ -90,52 +90,51 @@ class SetNewServicesBench
 
         $sm->setAlias('recursiveFactoryAlias1', 'factory1');
     }
-    
+
     public function benchSetInvokableClass()
     {
-        
+
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->setInvokableClass(BenchAsset\Foo::class, BenchAsset\Foo::class);
     }
-    
+
     public function benchAddDelegator()
     {
-        
+
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addDelegator(BenchAsset\Foo::class, DelegatorFactoryFoo::class);
     }
-    
+
     public function benchAddInitializerByClassName()
     {
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addInitializer(BenchAsset\InitializerFoo::class);
     }
-    
+
     public function benchAddInitializerByInstance()
     {
-        
+
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addInitializer($this->initializer);
     }
-    
+
     public function benchAddAbstractFactoryByClassName()
     {
-        
+
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addAbstractFactory(BenchAsset\AbstractFactoryFoo::class);
     }
-    
+
     public function benchAddAbstractFactoryByInstance()
     {
-        
+
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addAbstractFactory($this->abstractFactory);
     }
-    
 }

--- a/benchmarks/SetNewServicesBench.php
+++ b/benchmarks/SetNewServicesBench.php
@@ -11,6 +11,7 @@ use PhpBench\Benchmark\Metadata\Annotations\Iterations;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 use PhpBench\Benchmark\Metadata\Annotations\Warmup;
 use Zend\ServiceManager\ServiceManager;
+use ZendBench\ServiceManager\BenchAsset\DelegatorFactoryFoo;
 
 /**
  * @Revs(1000)
@@ -61,79 +62,87 @@ class SetNewServicesBench
 
     public function benchSetService()
     {
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
-
         $sm->setService('service2', new \stdClass());
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchSetFactory()
     {
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
-
         $sm->setFactory('factory2', BenchAsset\FactoryFoo::class);
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchSetAlias()
     {
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
-
         $sm->setAlias('factoryAlias2', 'factory1');
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchOverrideAlias()
     {
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
-
         $sm->setAlias('recursiveFactoryAlias1', 'factory1');
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchSetInvokableClass()
     {
-
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->setInvokableClass(BenchAsset\Foo::class, BenchAsset\Foo::class);
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchAddDelegator()
     {
-
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addDelegator(BenchAsset\Foo::class, DelegatorFactoryFoo::class);
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchAddInitializerByClassName()
     {
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addInitializer(BenchAsset\InitializerFoo::class);
     }
 
-    public function benchAddInitializerByInstance()
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
+   public function benchAddInitializerByInstance()
     {
-
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addInitializer($this->initializer);
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchAddAbstractFactoryByClassName()
     {
-
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addAbstractFactory(BenchAsset\AbstractFactoryFoo::class);
     }
 
+    /**
+     * @todo @link https://github.com/phpbench/phpbench/issues/304
+     */
     public function benchAddAbstractFactoryByInstance()
     {
-
-        // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
         $sm->addAbstractFactory($this->abstractFactory);
     }

--- a/benchmarks/SetNewServicesBench.php
+++ b/benchmarks/SetNewServicesBench.php
@@ -123,7 +123,7 @@ class SetNewServicesBench
     /**
      * @todo @link https://github.com/phpbench/phpbench/issues/304
      */
-   public function benchAddInitializerByInstance()
+    public function benchAddInitializerByInstance()
     {
         $sm = clone $this->sm;
         $sm->addInitializer($this->initializer);

--- a/benchmarks/SetNewServicesBench.php
+++ b/benchmarks/SetNewServicesBench.php
@@ -43,18 +43,21 @@ class SetNewServicesBench
                 'recursiveFactoryAlias1' => 'factoryAlias1',
                 'recursiveFactoryAlias2' => 'recursiveFactoryAlias1',
             ],
-            'abstract_factories' => [
-                BenchAsset\AbstractFactoryFoo::class
-            ],
         ];
 
         for ($i = 0; $i <= self::NUM_SERVICES; $i++) {
             $config['factories']["factory_$i"] = BenchAsset\FactoryFoo::class;
             $config['aliases']["alias_$i"]     = "service_$i";
+            $config['abstract_factories'][] = BenchAsset\AbstractFactoryFoo::class;
+            $config['invokables']['invokable_$i'] = BenchAsset\Foo::class;
+            $config['delegators']['delegator_$i'] = [ DelegatorFactoryFoo::class ];
         }
-
+        
+        $this->initializer = new BenchAsset\InitializerFoo();
+        $this->abstractFactory = new BenchAsset\AbstractFactoryFoo();
         $this->sm = new ServiceManager($config);
     }
+        
 
     public function benchSetService()
     {
@@ -80,11 +83,59 @@ class SetNewServicesBench
         $sm->setAlias('factoryAlias2', 'factory1');
     }
 
-    public function benchSetAliasOverrided()
+    public function benchOverrideAlias()
     {
         // @todo @link https://github.com/phpbench/phpbench/issues/304
         $sm = clone $this->sm;
 
         $sm->setAlias('recursiveFactoryAlias1', 'factory1');
     }
+    
+    public function benchSetInvokableClass()
+    {
+        
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+        $sm->setInvokableClass(BenchAsset\Foo::class, BenchAsset\Foo::class);
+    }
+    
+    public function benchAddDelegator()
+    {
+        
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+        $sm->addDelegator(BenchAsset\Foo::class, DelegatorFactoryFoo::class);
+    }
+    
+    public function benchAddInitializerByClassName()
+    {
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+        $sm->addInitializer(BenchAsset\InitializerFoo::class);
+    }
+    
+    public function benchAddInitializerByInstance()
+    {
+        
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+        $sm->addInitializer($this->initializer);
+    }
+    
+    public function benchAddAbstractFactoryByClassName()
+    {
+        
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+        $sm->addAbstractFactory(BenchAsset\AbstractFactoryFoo::class);
+    }
+    
+    public function benchAddAbstractFactoryByInstance()
+    {
+        
+        // @todo @link https://github.com/phpbench/phpbench/issues/304
+        $sm = clone $this->sm;
+        $sm->addAbstractFactory($this->abstractFactory);
+    }
+    
 }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -249,35 +249,19 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function has($name)
     {
+        $resolvedName = $this->aliases[$name] ?? $name;
         // Check services and factories first to speedup the most common requests.
-        if (isset($this->services[$name]) || isset($this->factories[$name])) {
+        if (isset($this->services[$resolvedName]) || isset($this->factories[$resolvedName])) {
             return true;
         }
 
         // Check abstract factories next.
         foreach ($this->abstractFactories as $abstractFactory) {
-            if ($abstractFactory->canCreate($this->creationContext, $name)) {
-                return true;
-            }
-        }
-
-        // If $name is not an alias, we are done.
-        if (! isset($this->aliases[$name])) {
-            return false;
-        }
-
-        // Check aliases.
-        $resolvedName = $this->aliases[$name];
-        if (isset($this->services[$resolvedName]) || isset($this->factories[$resolvedName])) {
-            return true;
-        }
-
-        // Check abstract factories on the $resolvedName as well.
-        foreach ($this->abstractFactories as $abstractFactory) {
             if ($abstractFactory->canCreate($this->creationContext, $resolvedName)) {
                 return true;
             }
         }
+        return false;
     }
 
     /**
@@ -386,12 +370,8 @@ class ServiceManager implements ServiceLocatorInterface
 
         // For abstract factories and initializers, we always directly
         // instantiate them to avoid checks during service construction.
-        if (isset($config['abstract_factories'])) {
-            $abstractFactories = $config['abstract_factories'];
-            // $key not needed, but foreach is faster than foreach + array_values.
-            foreach ($abstractFactories as $key => $abstractFactory) {
-                $this->resolveAbstractFactoryInstance($abstractFactory);
-            }
+        if (! empty($config['abstract_factories'])) {
+            $this->resolveAbstractFactories($config['abstract_factories']);
         }
 
         if (isset($config['initializers'])) {
@@ -465,7 +445,12 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function mapLazyService($name, $class = null)
     {
-        $this->configure(['lazy_services' => ['class_map' => [$name => $class ?: $name]]]);
+        if (! isset($this->services[$name]) || $this->allowOverride) {
+            $this->lazyServices = array_merge_recursive(['class_map' => [$name => $class ?? $name]]);
+            $this->lazyServicesDelegator = null;
+            return;
+        }
+        throw ContainerModificationsNotAllowedException::fromExistingService($name);
     }
 
     /**
@@ -476,7 +461,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function addAbstractFactory($factory)
     {
-        $this->resolveAbstractFactoryInstance($factory);
+        $this->resolveAbstractFactories([$factory]);
     }
 
     /**
@@ -488,7 +473,11 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function addDelegator($name, $factory)
     {
-        $this->configure(['delegators' => [$name => [$factory]]]);
+        if (! isset($this->services[$name]) || $this->allowOverride) {
+            $this->delegators = array_merge_recursive($this->delegators, [$name => [$factory]]);
+            return;
+        }
+        throw ContainerModificationsNotAllowedException::fromExistingService($name);
     }
 
     /**
@@ -498,7 +487,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function addInitializer($initializer)
     {
-        $this->configure(['initializers' => [$initializer]]);
+        $this->resolveInitializers([$initializer]);
     }
 
     /**
@@ -924,25 +913,26 @@ class ServiceManager implements ServiceLocatorInterface
      * Instantiate abstract factories in order to avoid checks during service construction.
      *
      * @param string[]|Factory\AbstractFactoryInterface[] $abstractFactories
-     *
-     * @return void
      */
-    private function resolveAbstractFactoryInstance($abstractFactory)
+    private function resolveAbstractFactories($abstractFactories)
     {
-        if (is_string($abstractFactory) && class_exists($abstractFactory)) {
-            // Cached string factory name
-            if (! isset($this->cachedAbstractFactories[$abstractFactory])) {
-                $this->cachedAbstractFactories[$abstractFactory] = new $abstractFactory();
+        foreach ($abstractFactories as $_ => $abstractFactory) {
+            if (is_string($abstractFactory) && class_exists($abstractFactory)) {
+                // cached string
+                if (! isset($this->cachedAbstractFactories[$abstractFactory])) {
+                    $this->cachedAbstractFactories[$abstractFactory] = new $abstractFactory();
+                }
+
+                $abstractFactory = $this->cachedAbstractFactories[$abstractFactory];
             }
 
-            $abstractFactory = $this->cachedAbstractFactories[$abstractFactory];
-        }
+            if ($abstractFactory instanceof Factory\AbstractFactoryInterface) {
+                $abstractFactoryObjHash = spl_object_hash($abstractFactory);
+                $this->abstractFactories[$abstractFactoryObjHash] = $abstractFactory;
+                return;
+            }
 
-        if (! $abstractFactory instanceof Factory\AbstractFactoryInterface) {
             throw InvalidArgumentException::fromInvalidAbstractFactory($abstractFactory);
         }
-
-        $abstractFactoryObjHash = spl_object_hash($abstractFactory);
-        $this->abstractFactories[$abstractFactoryObjHash] = $abstractFactory;
     }
 }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -393,11 +393,10 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setAlias($alias, $target)
     {
-        if (! isset($this->services[$alias]) || $this->allowOverride) {
-            $this->mapAliasToTarget($alias, $target);
-            return;
+        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+            throw ContainerModificationsNotAllowedException::fromExistingService($alias);
         }
-        throw ContainerModificationsNotAllowedException::fromExistingService($alias);
+        $this->mapAliasToTarget($alias, $target);
     }
 
     /**
@@ -411,11 +410,10 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setInvokableClass($name, $class = null)
     {
-        if (! isset($this->services[$name]) || $this->allowOverride) {
-            $this->createAliasesAndFactoriesForInvokables([$name => $class ?? $name]);
-            return;
+        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+            throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
-        throw ContainerModificationsNotAllowedException::fromExistingService($name);
+        $this->createAliasesAndFactoriesForInvokables([$name => $class ?? $name]);
     }
 
     /**
@@ -429,11 +427,10 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setFactory($name, $factory)
     {
-        if (! isset($this->services[$name]) || $this->allowOverride) {
-            $this->factories[$name] = $factory;
-            return;
+        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+            throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
-        throw ContainerModificationsNotAllowedException::fromExistingService($name);
+        $this->factories[$name] = $factory;
     }
 
     /**
@@ -445,11 +442,10 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function addDelegator($name, $factory)
     {
-        if (! isset($this->services[$name]) || $this->allowOverride) {
-            $this->delegators = array_merge_recursive($this->delegators, [$name => [$factory]]);
-            return;
+        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+            throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
-        throw ContainerModificationsNotAllowedException::fromExistingService($name);
+        $this->delegators = array_merge_recursive($this->delegators, [$name => [$factory]]);
     }
 
     /**

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -411,7 +411,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setInvokableClass($name, $class = null)
     {
-        if (! isset($this->services[$name]) && $this->allowOverride) {
+        if (! isset($this->services[$name]) || $this->allowOverride) {
             $this->createAliasesAndFactoriesForInvokables([$name => $class ?? $name]);
             return;
         }
@@ -429,8 +429,11 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setFactory($name, $factory)
     {
-
-        $this->factories[$name] = $factory;
+        if (! isset($this->services[$name]) || $this->allowOverride) {
+            $this->factories[$name] = $factory;
+            return;
+        }
+        throw ContainerModificationsNotAllowedException::fromExistingService($name);
     }
 
     /**
@@ -472,6 +475,7 @@ class ServiceManager implements ServiceLocatorInterface
         if (! isset($this->services[$name]) ||$this->allowOverride) {
             $this->lazyServices = array_merge_recursive(['class_map' => [$name => $class ?? $name]]);
             $this->lazyServicesDelegator = null;
+            return;
         }
         throw ContainerModificationsNotAllowedException::fromExistingService($name);
     }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -522,7 +522,6 @@ class ServiceManager implements ServiceLocatorInterface
             return;
         }
         throw ContainerModificationsNotAllowedException::fromExistingService($name);
-
     }
 
     /**
@@ -884,6 +883,7 @@ class ServiceManager implements ServiceLocatorInterface
             if ($aCursor === $tCursor) {
                 throw CyclicAliasException::fromCyclicAlias($alias, $this->aliases);
             }
+
             if (! isset($this->aliases[$tCursor])) {
                 continue;
             }

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -911,7 +911,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     private function resolveAbstractFactories($abstractFactories)
     {
-        foreach ($abstractFactories as $_ => $abstractFactory) {
+        foreach ($abstractFactories as $abstractFactory) {
             if (is_string($abstractFactory) && class_exists($abstractFactory)) {
                 // cached string
                 if (! isset($this->cachedAbstractFactories[$abstractFactory])) {

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -391,12 +391,12 @@ class ServiceManager implements ServiceLocatorInterface
      * @throws ContainerModificationsNotAllowedException if $alias already
      *     exists as a service and overrides are disallowed.
      */
-    public function setAlias($alias, $target)
+    public function setAlias($name, $target)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
-            throw ContainerModificationsNotAllowedException::fromExistingService($alias);
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
+            throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
-        $this->mapAliasToTarget($alias, $target);
+        $this->mapAliasToTarget($name, $target);
     }
 
     /**
@@ -410,7 +410,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setInvokableClass($name, $class = null)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
             throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
         $this->createAliasesAndFactoriesForInvokables([$name => $class ?? $name]);
@@ -427,7 +427,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setFactory($name, $factory)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
             throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
         $this->factories[$name] = $factory;
@@ -442,7 +442,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function mapLazyService($name, $class = null)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
             throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
         $this->lazyServices = array_merge_recursive(['class_map' => [$name => $class ?? $name]]);
@@ -469,7 +469,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function addDelegator($name, $factory)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
             throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
         $this->delegators = array_merge_recursive($this->delegators, [$name => [$factory]]);
@@ -495,7 +495,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setService($name, $service)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
             throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
         $this->services[$name] = $service;
@@ -511,7 +511,7 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function setShared($name, $flag)
     {
-        if (isset($this->services[$alias]) && ! $this->allowOverride) {
+        if (isset($this->services[$name]) && ! $this->allowOverride) {
             throw ContainerModificationsNotAllowedException::fromExistingService($name);
         }
         $this->shared[$name] = (bool) $flag;

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -289,7 +289,6 @@ class ServiceManagerTest extends TestCase
         ->with($this->anything(), $this->equalTo('ServiceName'))
         ->willReturn(true);
         $this->assertTrue($serviceManager->has('Alias'));
-        
     }
 
     public static function sampleFactory()

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -306,28 +306,4 @@ class ServiceManagerTest extends TestCase
         $serviceManager = new SimpleServiceManager($config);
         $this->assertEquals(stdClass::class, get_class($serviceManager->get(stdClass::class)));
     }
-
-//     public function testMinimalCyclicAliasDefinitionShouldThrow()
-//     {
-//         $sm = new ServiceManager();
-
-//         $this->expectException(CyclicAliasException::class);
-//         $sm->setAlias('alias', 'alias');
-//     }
-
-//     public function testCoverageDepthFirstTaggingOnRecursiveAliasDefinitions()
-//     {
-//         $sm = new ServiceManager([
-//             'factories' => [
-//                 stdClass::class => InvokableFactory::class,
-//             ],
-//             'aliases' => [
-//                 'alias1' => 'alias2',
-//                 'alias2' => 'alias3',
-//                 'alias3' => stdClass::class,
-//             ],
-//         ]);
-//         $this->assertSame($sm->get('alias1'), $sm->get('alias2'));
-//         $this->assertSame($sm->get(stdClass::class), $sm->get('alias1'));
-//     }
 }


### PR DESCRIPTION
Current master and develop branches provide a special treatment for invokables within sm configuration phase. This treatment requires to loop through the invokables array and perform actions and create an InvokableFactory entry for each Invokable and an alias if the name of the invokable is different from the invokable class name. This is a major bottleneck for configuration speed. This treatment alone takes about 30% of overall configuration time.

Here is the benchmark comparing master to this PR.

    benchmark: FetchNewServiceManagerBench
	+----------------------------------+-------------------+------------------+--------+
	| subject                          | suite:master:mean | suite:PR232:mean | factor |
	+----------------------------------+-------------------+------------------+--------+
	| benchFetchServiceManagerCreation | 872.000µs         | 218.000µs        | 4x     |
	+----------------------------------+-------------------+------------------+--------+

The replacement of an invokable by a factory and an alias can also be considered as a bug. Current service resolution precedence is:

1. Services
2. Aliases
3. Delegators
4. Factories
5. Abstract Factories

As @Ocramius said, there are use cases, where users want to provide a factory for an invokable class, because the particular application wants to apply configuration to the invokable object.

By defining an alias for the invokable class, this factory gets disabled efffectively.

This PR changes the treatment of invokables. They are stored in an $invokables array like the other items.
Now invokables get resolved to an InvokableFactory in getFactory now. The new resolution precedence is

1. Services
2. Aliases
3. Delegators
4. Factories
5. Invokables
6. Abstract Factories

I tried to discuss the problems of alias resolution precedence in #222. I do not know if there are discussions around that topic actually. At least nobody wanted to share his/her thoughts since I published that article weeks ago. Trouble with aliases could get eliminated by reducing them to aliases. That would mean to change the resolution precedence to 

1. Services
2. Delegators
3. Factories
4. Invokables
5. Abstract Factories
6. Aliases






