### PR TITLE
Adds test for issue #236

### DIFF
--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -931,17 +931,9 @@ trait CommonServiceLocatorBehaviorsTrait
     }
 
     /**
-     * The ServiceManager can change internal state on calls to get,
-     * build or has, latter not currently. Possible state changes
-     * are caching a factory, registering a service produced by
-     * a factory, ...
+     * Data provider
      *
-     * This tests performs three consecutive calls to build/get for
-     * each registered service to push the service manager through
-     * all internal states, thereby verifying that build/get/has
-     * remain stable through the internal states.
-     *
-     * @see testConsistencyOverInternalStates below
+     * @see testConsistencyOverInternalStates above
      *
      * @param ContainerInterface $smTemplate
      * @param string $name

--- a/test/TestAsset/AbstractFactoryFoo.php
+++ b/test/TestAsset/AbstractFactoryFoo.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @link      https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\AbstractFactoryInterface;
+
+class AbstractFactoryFoo implements AbstractFactoryInterface
+{
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        if ($requestedName === 'foo') {
+            return new Foo($options);
+        }
+        return false;
+    }
+
+    public function canCreate(ContainerInterface $container, $requestedName)
+    {
+        return ($requestedName === 'foo');
+    }
+}

--- a/test/TestAsset/Foo.php
+++ b/test/TestAsset/Foo.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @link      https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+class Foo
+{
+    protected $options;
+
+    public function __construct($options = null)
+    {
+        $this->options = $options;
+    }
+}

--- a/test/TestAsset/PassthroughDelegatorFactory.php
+++ b/test/TestAsset/PassthroughDelegatorFactory.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @link      https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\DelegatorFactoryInterface;
+
+class PassthroughDelegatorFactory implements DelegatorFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     * @see \Zend\ServiceManager\Factory\DelegatorFactoryInterface::__invoke()
+     */
+    public function __invoke(ContainerInterface $container, $name, callable $callback, array $options = null)
+    {
+        return call_user_func($callback);
+    }
+}


### PR DESCRIPTION
Adds a test addressing the issue described in #236. 

    /**
     * The ServiceManager can change internal state on calls to get,
     * build or has, latter not currently. Possible state changes
     * are caching a factory, registering a service produced by
     * a factory, resolving an alias and so on.
     *
     * This tests performs three consecutive calls to build/get for
     * each registered service to push the service manager through
     * all internal states, thereby verifying that build/get/has
     * remain stable through the internal states.
     */

The test does not make any assumptions about particular internal states the ServiceManager has or might have. The ServiceManager is treated as a blackbox in order to make sure, that the test is agnostic to possible future changes to the implementation of internal states. 
