### PR TITLE
Improved tests aliases with abstract factories.

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -278,6 +278,8 @@ class ServiceManager implements ServiceLocatorInterface
                 return true;
             }
         }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
There was an error in the testcase `testAbstractFactoryShouldBeCheckedForResolvedAliasesInsteadOfAliasName`
where the returnValueMap of phpunit was used wrong. This caused a false positive. The test was returning an
array which is interpreted as `TRUE`.

I discovered this when I added the `testResolvedAliasFromAbstractFactory`, which should do the opposite form the
earlier mentioned testcase.

Beside that I found a way that the servicemanager was returning `null` instead of returning false when the last fallback
on abstract factories failed.

I'm not sure if the `testAbstractFactoryShouldBeCheckedForResolvedAliasesInsteadOfAliasName` is still doing what was intended to do. So that might be a point of discussion. 