### PR TITLE
Use default values for type-hinted arguments if type not found in container

### DIFF
--- a/src/AbstractFactory/ReflectionBasedAbstractFactory.php
+++ b/src/AbstractFactory/ReflectionBasedAbstractFactory.php
@@ -218,7 +218,11 @@ class ReflectionBasedAbstractFactory implements AbstractFactoryInterface
         $type = $parameter->getClass()->getName();
         $type = isset($this->aliases[$type]) ? $this->aliases[$type] : $type;
 
-        if (! $container->has($type)) {
+        if ($container->has($type)) {
+            return $container->get($type);
+        }
+
+        if (! $parameter->isOptional()) {
             throw new ServiceNotFoundException(sprintf(
                 'Unable to create service "%s"; unable to resolve parameter "%s" using type hint "%s"',
                 $requestedName,
@@ -227,6 +231,8 @@ class ReflectionBasedAbstractFactory implements AbstractFactoryInterface
             ));
         }
 
-        return $container->get($type);
+        // Type not available in container, but the value is optional and has a
+        // default defined.
+        return $parameter->getDefaultValue();
     }
 }

--- a/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
+++ b/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
@@ -7,6 +7,7 @@
 
 namespace ZendTest\ServiceManager\AbstractFactory;
 
+use ArrayAccess;
 use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
@@ -153,5 +154,21 @@ class ReflectionBasedAbstractFactoryTest extends TestCase
         );
         $this->assertInstanceOf(TestAsset\ClassWithScalarDependencyDefiningDefaultValue::class, $instance);
         $this->assertEquals('bar', $instance->foo);
+    }
+
+    /**
+     * @see https://github.com/zendframework/zend-servicemanager/issues/239
+     */
+    public function testFactoryWillUseDefaultValueForTypeHintedArgument()
+    {
+        $this->container->has('config')->willReturn(false);
+        $this->container->has(ArrayAccess::class)->willReturn(false);
+        $factory = new ReflectionBasedAbstractFactory();
+        $instance = $factory(
+            $this->container->reveal(),
+            TestAsset\ClassWithTypehintedDefaultValue::class
+        );
+        $this->assertInstanceOf(TestAsset\ClassWithTypehintedDefaultValue::class, $instance);
+        $this->assertNull($instance->value);
     }
 }

--- a/test/AbstractFactory/TestAsset/ClassWithTypehintedDefaultValue.php
+++ b/test/AbstractFactory/TestAsset/ClassWithTypehintedDefaultValue.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-2018 for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-2018/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\ServiceManager\AbstractFactory\TestAsset;
+
+use ArrayAccess;
+
+class ClassWithTypehintedDefaultValue
+{
+    public $value;
+
+    public function __construct(ArrayAccess $value = null)
+    {
+        $this->value = null;
+    }
+}


### PR DESCRIPTION
Per #239, currently when an argument is type-hinted but has a default value (typically `null`), the factory raises an exception about not being able to retrieve the value from the container. In such cases, we can use the default value for the argument during injection.

Fixes #239.