### PR TITLE
Added more test for shared services (aliases, factories, invokables)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "ocramius/proxy-manager": "^2.1.1",
         "phpbench/phpbench": "^0.13.0",
         "phpunit/phpunit": "^6.4.4",
-        "zendframework/zend-coding-standard": "~1.0.0"
+        "zendframework/zend-coding-standard": "~1.0.0",
+        "zendframework/zend-container-config-test": "^0.2.1"
     },
     "provide": {
         "psr/container-implementation": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bba5f6d05be1ae91bc424cd3510f5bbc",
+    "content-hash": "f280e96d0b05401d973f1fdd15dc0c90",
     "packages": [
         {
             "name": "psr/container",
@@ -2862,6 +2862,61 @@
                 "zf"
             ],
             "time": "2016-11-09T21:30:43+00:00"
+        },
+        {
+            "name": "zendframework/zend-container-config-test",
+            "version": "0.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-container-config-test.git",
+                "reference": "ebc45b7b6b2a8e382fe8a4a4d6c74a196fe53554"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-container-config-test/zipball/ebc45b7b6b2a8e382fe8a4a4d6c74a196fe53554",
+                "reference": "ebc45b7b6b2a8e382fe8a4a4d6c74a196fe53554",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "psr/container": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0.2",
+                "zendframework/zend-auradi-config": "^1.0.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-pimple-config": "^1.1",
+                "zendframework/zend-servicemanager": "^3.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/TestAsset/function-factory.php",
+                    "src/TestAsset/function-factory-with-name.php"
+                ],
+                "psr-4": {
+                    "Zend\\ContainerConfigTest\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Expressive PSR-11 container configuration tests",
+            "keywords": [
+                "PSR-11",
+                "ZendFramework",
+                "container",
+                "expressive",
+                "test",
+                "zf"
+            ],
+            "time": "2018-04-12T18:58:34+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",

--- a/test/ContainerTest.php
+++ b/test/ContainerTest.php
@@ -7,93 +7,16 @@
 
 namespace ZendTest\ServiceManager;
 
-use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Zend\ContainerConfigTest\AbstractExpressiveContainerConfigTest;
+use Zend\ContainerConfigTest\SharedTestTrait;
 use Zend\ServiceManager\ServiceManager;
 
-class ContainerTest extends TestCase
+class ContainerTest extends AbstractExpressiveContainerConfigTest
 {
-    public function config()
-    {
-        yield 'factories' => [['factories' => ['service' => TestAsset\SampleFactory::class]]];
-        yield 'invokables' => [['invokables' => ['service' => TestAsset\InvokableObject::class]]];
-        yield 'aliases-invokables' => [
-            [
-                'aliases' => ['service' => TestAsset\InvokableObject::class],
-                'invokables' => [TestAsset\InvokableObject::class => TestAsset\InvokableObject::class],
-            ],
-        ];
-        yield 'aliases-factories' => [
-            [
-                'aliases' => ['service' => TestAsset\InvokableObject::class],
-                'factories' => [TestAsset\InvokableObject::class => TestAsset\SampleFactory::class],
-            ],
-        ];
-    }
+    use SharedTestTrait;
 
-    /**
-     * @dataProvider config
-     */
-    public function testIsSharedByDefault(array $config)
-    {
-        $container = $this->createContainer($config);
-
-        $service1 = $container->get('service');
-        $service2 = $container->get('service');
-
-        $this->assertSame($service1, $service2);
-    }
-
-    /**
-     * @dataProvider config
-     */
-    public function testCanDisableSharedByDefault(array $config)
-    {
-        $container = $this->createContainer(array_merge($config, [
-            'shared_by_default' => false,
-        ]));
-
-        $service1 = $container->get('service');
-        $service2 = $container->get('service');
-
-        $this->assertNotSame($service1, $service2);
-    }
-
-    /**
-     * @dataProvider config
-     */
-    public function testCanDisableSharedForSingleService(array $config)
-    {
-        $container = $this->createContainer(array_merge($config, [
-            'shared' => [
-                'service' => false,
-            ],
-        ]));
-
-        $service1 = $container->get('service');
-        $service2 = $container->get('service');
-
-        $this->assertNotSame($service1, $service2);
-    }
-
-    /**
-     * @dataProvider config
-     */
-    public function testCanEnableSharedForSingleService(array $config)
-    {
-        $container = $this->createContainer(array_merge($config, [
-            'shared_by_default' => false,
-            'shared' => [
-                'service' => true,
-            ],
-        ]));
-
-        $service1 = $container->get('service');
-        $service2 = $container->get('service');
-
-        $this->assertSame($service1, $service2);
-    }
-
-    private function createContainer(array $config)
+    protected function createContainer(array $config) : ContainerInterface
     {
         return new ServiceManager($config);
     }

--- a/test/ContainerTest.php
+++ b/test/ContainerTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-servicemanager/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\ServiceManager;
+
+use PHPUnit\Framework\TestCase;
+use Zend\ServiceManager\ServiceManager;
+
+class ContainerTest extends TestCase
+{
+    public function config()
+    {
+        yield 'factories' => [['factories' => ['service' => TestAsset\SampleFactory::class]]];
+        yield 'invokables' => [['invokables' => ['service' => TestAsset\InvokableObject::class]]];
+        yield 'aliases-invokables' => [
+            [
+                'aliases' => ['service' => TestAsset\InvokableObject::class],
+                'invokables' => [TestAsset\InvokableObject::class => TestAsset\InvokableObject::class],
+            ],
+        ];
+        yield 'aliases-factories' => [
+            [
+                'aliases' => ['service' => TestAsset\InvokableObject::class],
+                'factories' => [TestAsset\InvokableObject::class => TestAsset\SampleFactory::class],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider config
+     */
+    public function testIsSharedByDefault(array $config)
+    {
+        $container = $this->createContainer($config);
+
+        $service1 = $container->get('service');
+        $service2 = $container->get('service');
+
+        $this->assertSame($service1, $service2);
+    }
+
+    /**
+     * @dataProvider config
+     */
+    public function testCanDisableSharedByDefault(array $config)
+    {
+        $container = $this->createContainer(array_merge($config, [
+            'shared_by_default' => false,
+        ]));
+
+        $service1 = $container->get('service');
+        $service2 = $container->get('service');
+
+        $this->assertNotSame($service1, $service2);
+    }
+
+    /**
+     * @dataProvider config
+     */
+    public function testCanDisableSharedForSingleService(array $config)
+    {
+        $container = $this->createContainer(array_merge($config, [
+            'shared' => [
+                'service' => false,
+            ],
+        ]));
+
+        $service1 = $container->get('service');
+        $service2 = $container->get('service');
+
+        $this->assertNotSame($service1, $service2);
+    }
+
+    /**
+     * @dataProvider config
+     */
+    public function testCanEnableSharedForSingleService(array $config)
+    {
+        $container = $this->createContainer(array_merge($config, [
+            'shared_by_default' => false,
+            'shared' => [
+                'service' => true,
+            ],
+        ]));
+
+        $service1 = $container->get('service');
+        $service2 = $container->get('service');
+
+        $this->assertSame($service1, $service2);
+    }
+
+    private function createContainer(array $config)
+    {
+        return new ServiceManager($config);
+    }
+}


### PR DESCRIPTION
During the work on expressive @weierophinney set shared service to `false`  for `ResponseInterface` service. It means every call of the `get` method on the service manager will create new instance of `ResponseInterface`. Please see:
https://github.com/zendframework/zend-expressive/pull/543#discussion_r165378017

In this PR I'd like to check if `shared` services work correctly with all types of services and then provide the same functionality for other containers:
- [zend-pimple-config](https://github.com/zendframework/zend-pimple-config) - see: https://github.com/zendframework/zend-pimple-config/pull/6
- [zend-auradi-config](https://github.com/zendframework/zend-auradi-config)

to have exactly the same behaviour with different container managers.

This is just basics: I'm testing here factories and invokables and both with aliases. Aliases complicates all a bit, because then we can have many cases, let say:

```php
`aliases` => [
    'alias' => 'service',
],
'invokables' => [
    'service' => MyService::class,
],
'shared' => [
    // all different combinations of these:
    // 'alias' => false,
    // 'service' => true,
],
```

And if we include also `shared_by_default` I'm not sure what should be expected results in all of these cases.

Tests in this PR covers part from: https://github.com/zendframework/zend-servicemanager/blob/9f35a104b8d4d3b32da5f4a3b6efc0dd62e5af42/test/CommonServiceLocatorBehaviorsTrait.php#L38-L100
but these are just for services created through `factories`.

Probably we should add more tests, but I don't know what should be the behaviour, for example with config:
```php
'services' => [
    'service' => new MyService(),
],
'shared' => [
    'service' => false,
],
```
should we return always cloned instance of `service` or `shared` does not work with `services` only with factories/invokables/abstract_factories/delegators... ?

**Update:**
Maybe we should extract these tests to separate repository and use them for all containers integration? I guess we'd like to have the same behaviour of containers with the same configuration.