### PR TITLE
Detect cyclic dependency using reflection abstract factory

### DIFF
--- a/test/AbstractFactory/TestAsset/DecoratorWithCyclicDependencyOnInterface.php
+++ b/test/AbstractFactory/TestAsset/DecoratorWithCyclicDependencyOnInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\AbstractFactory\TestAsset;
+
+final class DecoratorWithCyclicDependencyOnInterface implements SampleInterface
+{
+    public function __construct(SampleInterface $wrapped)
+    {
+    }
+}


### PR DESCRIPTION
This is a new feature whereby cyclic dependencies are detected in a bit of an edge case. Example illustrated here: https://gist.github.com/asgrim/72f3ee4c25b901ffed58501657ea98da

I've written the test which demonstrates what I'm trying to do, but the implementation I feel is really sub-par however. My plan to implement was simply to check if `$requestedName === $type` (i.e. the requested service name is the same as the parameter type being used), but in practice this doesn't work because `$requestedName` is actually the *resolved* name:

https://github.com/zendframework/zend-servicemanager/blob/develop/src/ServiceManager.php#L209-L222

On L209 the alias is resolved, and on L222 `doCreate` is called with the `$resolvedName` so we never have the actual originally requested service name.

Therefore the only solution I could come up with for now was to check if the `$container` is a `ServiceManager` and reverse-engineer the service name to the original alias. Really not keen on this though, but I'm lacking on any better ideas. Feedback welcome here! :+1:

It's worth adding that in real terms, this is a user error, but I just wanted to catch this situation and provide some useful feedback (instead of something unclear `Maximum function nesting level of '500' reached, aborting!`), so if there's not a practical way to solve this problem, it simply may not be worth the effort.