### PR TITLE
remove redundant isset(s)

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -317,7 +317,7 @@ class ServiceManager implements ServiceLocatorInterface
             $this->services = $config['services'] + $this->services;
         }
 
-        if (isset($config['invokables']) && ! empty($config['invokables'])) {
+        if (! empty($config['invokables'])) {
             $aliases   = $this->createAliasesForInvokables($config['invokables']);
             $factories = $this->createFactoriesForInvokables($config['invokables']);
 
@@ -356,7 +356,7 @@ class ServiceManager implements ServiceLocatorInterface
 
         // If lazy service configuration was provided, reset the lazy services
         // delegator factory.
-        if (isset($config['lazy_services']) && ! empty($config['lazy_services'])) {
+        if (! empty($config['lazy_services'])) {
             $this->lazyServices          = array_merge_recursive($this->lazyServices, $config['lazy_services']);
             $this->lazyServicesDelegator = null;
         }


### PR DESCRIPTION
when we are also testing with `! empty()` I believe we can skip `isset()` checks, as the execution speed is nearly the same (but it will double for positive isset)