### PR TITLE
remove invokable redundant condition

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -866,11 +866,6 @@ class ServiceManager implements ServiceLocatorInterface
     {
         $factories = [];
         foreach ($invokables as $name => $class) {
-            if ($name === $class) {
-                $factories[$name] = Factory\InvokableFactory::class;
-                continue;
-            }
-
             $factories[$class] = Factory\InvokableFactory::class;
         }
         return $factories;


### PR DESCRIPTION
In `createFactoriesForInvokables` when `$name === $class` in line 869 then in line 870
```php
$factories[$name] = Factory\InvokableFactory::class;
//is equivalent to
$factories[$class] = Factory\InvokableFactory::class;
```

so there is no need for a conditional assignment since we always use the `$class` name as service key (and in cases where `$name !== $class`, aliases are added via `createAliasesForInvokables`)