### PR TITLE
ReflectionBasedAbstractFactory should not be expected to instantiate private constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#268](https://github.com/zendframework/zend-servicemanager/pull/268) Fixes
+  ReflectionBasedAbstractFactory trying to instantiate classes with private
+  constructors
 
 ## 3.3.2 - 2018-01-29
 

--- a/src/AbstractFactory/ReflectionBasedAbstractFactory.php
+++ b/src/AbstractFactory/ReflectionBasedAbstractFactory.php
@@ -137,7 +137,7 @@ class ReflectionBasedAbstractFactory implements AbstractFactoryInterface
         return class_exists($requestedName) && $this->canCallConstructor($requestedName);
     }
 
-    private function canCallConstructor(string $requestedName) : bool
+    private function canCallConstructor($requestedName)
     {
         $constructor = (new ReflectionClass($requestedName))->getConstructor();
 

--- a/src/AbstractFactory/ReflectionBasedAbstractFactory.php
+++ b/src/AbstractFactory/ReflectionBasedAbstractFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @see       https://github.com/zendframework/zend-servicemanager for the canonical source repository
  * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @license   https://github.com/zendframework/zend-servicemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ServiceManager\AbstractFactory;

--- a/src/AbstractFactory/ReflectionBasedAbstractFactory.php
+++ b/src/AbstractFactory/ReflectionBasedAbstractFactory.php
@@ -141,11 +141,7 @@ class ReflectionBasedAbstractFactory implements AbstractFactoryInterface
     {
         $constructor = (new ReflectionClass($requestedName))->getConstructor();
 
-        if ($constructor === null) {
-            return true;
-        }
-
-        return $constructor->isPublic();
+        return $constructor === null || $constructor->isPublic();
     }
 
     /**

--- a/src/AbstractFactory/ReflectionBasedAbstractFactory.php
+++ b/src/AbstractFactory/ReflectionBasedAbstractFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -131,18 +131,12 @@ class ReflectionBasedAbstractFactory implements AbstractFactoryInterface
 
     /**
      * {@inheritDoc}
-     * @throws \ReflectionException
      */
     public function canCreate(ContainerInterface $container, $requestedName)
     {
         return class_exists($requestedName) && $this->canCallConstructor($requestedName);
     }
 
-    /**
-     * @param string $requestedName
-     * @return bool
-     * @throws \ReflectionException
-     */
     private function canCallConstructor(string $requestedName) : bool
     {
         $constructor = (new ReflectionClass($requestedName))->getConstructor();

--- a/src/AbstractFactory/ReflectionBasedAbstractFactory.php
+++ b/src/AbstractFactory/ReflectionBasedAbstractFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -131,10 +131,27 @@ class ReflectionBasedAbstractFactory implements AbstractFactoryInterface
 
     /**
      * {@inheritDoc}
+     * @throws \ReflectionException
      */
     public function canCreate(ContainerInterface $container, $requestedName)
     {
-        return class_exists($requestedName);
+        return class_exists($requestedName) && $this->canCallConstructor($requestedName);
+    }
+
+    /**
+     * @param string $requestedName
+     * @return bool
+     * @throws \ReflectionException
+     */
+    private function canCallConstructor(string $requestedName) : bool
+    {
+        $constructor = (new ReflectionClass($requestedName))->getConstructor();
+
+        if ($constructor === null) {
+            return true;
+        }
+
+        return $constructor->isPublic();
     }
 
     /**

--- a/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
+++ b/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -10,11 +10,13 @@ namespace ZendTest\ServiceManager\AbstractFactory;
 use ArrayAccess;
 use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Zend\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 
 class ReflectionBasedAbstractFactoryTest extends TestCase
 {
+    /** @var ContainerInterface|ObjectProphecy */
     private $container;
 
     public function setUp()
@@ -38,10 +40,7 @@ class ReflectionBasedAbstractFactoryTest extends TestCase
         $this->assertFalse($factory->canCreate($this->container->reveal(), $requestedName));
     }
 
-    /**
-     * @throws \ReflectionException
-     */
-    public function testCanCreateReturnsFalseWhenConstructorIsPrivate() : void
+    public function testCanCreateReturnsFalseWhenConstructorIsPrivate()
     {
         self::assertFalse(
             (new ReflectionBasedAbstractFactory())->canCreate(

--- a/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
+++ b/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
@@ -51,7 +51,7 @@ class ReflectionBasedAbstractFactoryTest extends TestCase
         );
     }
 
-    public function testCanCreateReturnsTrueWhenClassHasNoConstructor() : void
+    public function testCanCreateReturnsTrueWhenClassHasNoConstructor()
     {
         self::assertTrue(
             (new ReflectionBasedAbstractFactory())->canCreate(

--- a/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
+++ b/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @see       https://github.com/zendframework/zend-servicemanager for the canonical source repository
  * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @license   https://github.com/zendframework/zend-servicemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ServiceManager\AbstractFactory;

--- a/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
+++ b/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -15,6 +15,8 @@ use Zend\ServiceManager\Exception\ServiceNotFoundException;
 
 class ReflectionBasedAbstractFactoryTest extends TestCase
 {
+    private $container;
+
     public function setUp()
     {
         $this->container = $this->prophesize(ContainerInterface::class);
@@ -34,6 +36,20 @@ class ReflectionBasedAbstractFactoryTest extends TestCase
     {
         $factory = new ReflectionBasedAbstractFactory();
         $this->assertFalse($factory->canCreate($this->container->reveal(), $requestedName));
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function testCanCreateReturnsFalseWhenConstructorIsPrivate() : void
+    {
+        self::assertFalse(
+            (new ReflectionBasedAbstractFactory())->canCreate(
+                $this->container->reveal(),
+                TestAsset\ClassWithPrivateConstructor::class
+            ),
+            'ReflectionBasedAbstractFactory should not be able to instantiate a class with a private constructor'
+        );
     }
 
     public function testFactoryInstantiatesClassDirectlyIfItHasNoConstructor()

--- a/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
+++ b/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
@@ -51,6 +51,17 @@ class ReflectionBasedAbstractFactoryTest extends TestCase
         );
     }
 
+    public function testCanCreateReturnsTrueWhenClassHasNoConstructor() : void
+    {
+        self::assertTrue(
+            (new ReflectionBasedAbstractFactory())->canCreate(
+                $this->container->reveal(),
+                TestAsset\ClassWithNoConstructor::class
+            ),
+            'ReflectionBasedAbstractFactory should be able to instantiate a class without a constructor'
+        );
+    }
+
     public function testFactoryInstantiatesClassDirectlyIfItHasNoConstructor()
     {
         $factory = new ReflectionBasedAbstractFactory();

--- a/test/AbstractFactory/TestAsset/ClassWithPrivateConstructor.php
+++ b/test/AbstractFactory/TestAsset/ClassWithPrivateConstructor.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @see       https://github.com/zendframework/zend-servicemanager for the canonical source repository
  * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @license   https://github.com/zendframework/zend-servicemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ServiceManager\AbstractFactory\TestAsset;

--- a/test/AbstractFactory/TestAsset/ClassWithPrivateConstructor.php
+++ b/test/AbstractFactory/TestAsset/ClassWithPrivateConstructor.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\AbstractFactory\TestAsset;
+
+class ClassWithPrivateConstructor
+{
+    private function __construct()
+    {
+    }
+}


### PR DESCRIPTION
I noticed that when using the `ReflectionBasedAbstractFactory`, it chokes when classes with `private` constructors are used. These types of classes should be ignored from the start, so I've updated `canCreate` to return `false` where any class has a `private` constructor.