### PR TITLE
Undefined $factory notice fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.7.11 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#269](https://github.com/zendframework/zend-servicemanager/pull/269) fixes a
+  regression whereby using static Callable strings caused an undefined variable
+  notice.
+
 ## 2.7.10 - 2017-12-05
 
 ### Added

--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -355,6 +355,8 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
         } elseif (is_array($callable)) {
             // reset both rewinds and returns the value of the first array element
             $factory = reset($callable);
+        } else {
+            $factory = null;
         }
 
         if ($factory instanceof Factory\InvokableFactory) {

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -437,6 +437,16 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(InvokableObject::class, $pluginManager->get('foo'));
     }
 
+    public function testStaticFactoryMethod()
+    {
+        $pluginManager = new FooPluginManager(new Config([
+            'factories' => [
+                'Foo' => 'ZendTest\ServiceManager\TestAsset\FooStaticFactory::createService',
+            ],
+        ]));
+        $this->assertInstanceOf(TestAsset\Foo::class, $pluginManager->get('foo'));
+    }
+
     public function testInvokableFactoryHasMutableOptions()
     {
         $pluginManager = new FooPluginManager($this->serviceManager);

--- a/test/TestAsset/FooStaticFactory.php
+++ b/test/TestAsset/FooStaticFactory.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+class FooStaticFactory
+{
+    public static function createService()
+    {
+        return new Foo;
+    }
+}

--- a/test/TestAsset/FooStaticFactory.php
+++ b/test/TestAsset/FooStaticFactory.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 


### PR DESCRIPTION
When a plugin manager uses a static class method as a factory (i.e. `FactoryClass::factoryMethod`), as of release 2.7.10, it causes an undefined variable notice to be thrown due to an uncovered else case. This pull request provides a test case to demonstrate the problem as well as a fix. This problem does not appear to exist in the 3.x code, so it is presumably a side effect of backporting to 2.7. However, for projects depending on earlier versions of the service manager, it can be a significant problem and should be corrected -- that is why I am targeting this PR against the release-2.7 branch.