### PR TITLE
define $initializer variable definition only when there is $this->servicesMap[$name] at LazyServiceFactory

### DIFF
--- a/src/Proxy/LazyServiceFactory.php
+++ b/src/Proxy/LazyServiceFactory.php
@@ -49,14 +49,14 @@ final class LazyServiceFactory implements DelegatorFactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, callable $callback, array $options = null)
     {
-        $initializer = function (&$wrappedInstance, LazyLoadingInterface $proxy) use ($callback) {
-            $proxy->setProxyInitializer(null);
-            $wrappedInstance = $callback();
-
-            return true;
-        };
-
         if (isset($this->servicesMap[$name])) {
+            $initializer = function (&$wrappedInstance, LazyLoadingInterface $proxy) use ($callback) {
+                $proxy->setProxyInitializer(null);
+                $wrappedInstance = $callback();
+
+                return true;
+            };
+
             return $this->proxyFactory->createProxy($this->servicesMap[$name], $initializer);
         }
 


### PR DESCRIPTION
- [x] Is this related to quality assurance?