### PR TITLE
docbock fix for ServiceManager::resolveAliases(): @return, not @returns; Causes bug in zf-annotation

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -609,7 +609,7 @@ class ServiceManager implements ServiceLocatorInterface
      *
      * @param string[] $aliases
      *
-     * @returns void
+     * @return void
      */
     private function resolveAliases(array $aliases)
     {


### PR DESCRIPTION
Submitted is a minor typographical fix for the docblock of ServiceManager::resolveAliases() which causes an exception when using for zf-annotations (and likely other doctrine annotation powered tooling).

```
Fatal error: Uncaught Doctrine\Common\Annotations\AnnotationException: 
[Semantical Error] The annotation "@returns" in method Zend\ServiceManager\ServiceManager::resolveAliases() was never imported. 
Did you maybe forget to add a "use" statement for this annotation? in /var/www/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationException.php on line 54
```

To reproduce:

1. Check out zend-framework-skeleton
2. Add zf-annotations to composer and config/application.php ( or in a module )
3. Attempt to access any route, and see the above error

Expected Behavior:
zf-annotation handles Doctrine `@Route()` annotations without errors

Proposed fix:
- change `@returns void` to `@return void` on line 612 of src/ServiceManager.php