### PR TITLE
Introduce psr to interop container decorator for plugin managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 3.4.0 - TBD
+
+### Added
+
+- [#275](https://github.com/zendframework/zend-servicemanager/pull/275) Enables plugin managers to accept as a creation context PSR Containers not implementing Interop interface
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 3.3.2 - 2018-01-29
 
 ### Added
@@ -61,7 +83,7 @@ All notable changes to this project will be documented in this file, in reverse 
   container-interop at a minimum version of 1.2.0, and adding a requirement on
   psr/container 1.0. `Zend\ServiceManager\ServiceLocatorInterface` now
   explicitly extends the `ContainerInterface` from both projects.
-  
+
   Factory interfaces still typehint against the container-interop variant, as
   changing the typehint would break backwards compatibility. Users can
   duck-type most of these interfaces, however, by creating callables or
@@ -339,7 +361,7 @@ Documentation is now available at http://zend-servicemanager.rtfd.org
   (previously, it was the third).
 
   Example:
-  
+
   ```php
   $sm = new \Zend\ServiceManager\ServiceManager([
       'factories'  => [
@@ -348,7 +370,7 @@ Documentation is now available at http://zend-servicemanager.rtfd.org
           'MyClassC'      => 'MyFactory' // This is equivalent as using ::class
       ],
   ]);
-  
+
   $sm->get(MyClassA::class); // MyFactory will receive MyClassA::class as second parameter
   ```
 
@@ -367,7 +389,7 @@ Documentation is now available at http://zend-servicemanager.rtfd.org
         if ($instance instanceof \Zend\Validator\ValidatorInterface) {
             return;
         }
-    
+
         throw new InvalidServiceException(sprintf(
             'Plugin manager "%s" expected an instance of type "%s", but "%s" was received',
              __CLASS__,
@@ -377,19 +399,19 @@ Documentation is now available at http://zend-servicemanager.rtfd.org
     }
   }
   ```
-  
+
   In version 3, this becomes:
-  
+
   ```php
   use Zend\ServiceManager\AbstractPluginManager;
   use Zend\Validator\ValidatorInterface;
-  
+
   class MyPluginManager extends AbstractPluginManager
   {
       protected $instanceOf = ValidatorInterface::class;
   }
   ```
-  
+
   Of course, you can still override the `validate` method if your logic is more
   complex.
 
@@ -433,17 +455,17 @@ changes, outlined in this section.
   service manager; you can pass the configuration array directly instead.
 
   In version 2.x:
-  
+
   ```php
   $config = new \Zend\ServiceManager\Config([
       'factories'  => [...]
   ]);
-  
+
   $sm = new \Zend\ServiceManager\ServiceManager($config);
   ```
-  
+
   In ZF 3.x:
-  
+
   ```php
   $sm = new \Zend\ServiceManager\ServiceManager([
       'factories'  => [...]
@@ -472,7 +494,7 @@ changes, outlined in this section.
   argument if present.
 
   For instance, here is a simple version 2.x factory:
-  
+
   ```php
   class MyFactory implements FactoryInterface
   {
@@ -482,9 +504,9 @@ changes, outlined in this section.
       }
   }
   ```
-  
+
   The equivalent version 3 factory:
-  
+
   ```php
   class MyFactory implements FactoryInterface
   {
@@ -514,23 +536,23 @@ changes, outlined in this section.
   through the interface.
 
   In version 2.x, if a factory was set to a service name defined in a plugin manager:
-  
+
   ```php
   class MyFactory implements FactoryInterface
   {
       function createService(ServiceLocatorInterface $sl)
       {
           // $sl is actually a plugin manager
-        
+
           $parentLocator = $sl->getServiceLocator();
-        
+
           // ...
       }
   }
   ```
-  
+
   In version 3:
-  
+
   ```php
   class MyFactory implements FactoryInterface
   {

--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -8,6 +8,7 @@
 namespace Zend\ServiceManager;
 
 use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 
 /**
@@ -52,6 +53,11 @@ abstract class AbstractPluginManager extends ServiceManager implements PluginMan
      */
     public function __construct($configInstanceOrParentLocator = null, array $config = [])
     {
+        if ($configInstanceOrParentLocator instanceof PsrContainerInterface
+            && ! $configInstanceOrParentLocator instanceof ContainerInterface
+        ) {
+            $configInstanceOrParentLocator = new PsrContainerDecorator($configInstanceOrParentLocator);
+        }
         if (null !== $configInstanceOrParentLocator
             && ! $configInstanceOrParentLocator instanceof ConfigInterface
             && ! $configInstanceOrParentLocator instanceof ContainerInterface

--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -56,6 +56,11 @@ abstract class AbstractPluginManager extends ServiceManager implements PluginMan
         if ($configInstanceOrParentLocator instanceof PsrContainerInterface
             && ! $configInstanceOrParentLocator instanceof ContainerInterface
         ) {
+            /**
+             * {@see \Zend\ServiceManager\Factory\FactoryInterface} typehints
+             * against interop container and as such cannot accept non-interop
+             * psr container. Decorate it as interop.
+             */
             $configInstanceOrParentLocator = new PsrContainerDecorator($configInstanceOrParentLocator);
         }
         if (null !== $configInstanceOrParentLocator

--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -48,7 +48,7 @@ abstract class AbstractPluginManager extends ServiceManager implements PluginMan
      * factories; for $config, {@see \Zend\ServiceManager\ServiceManager::configure()}
      * for details on its accepted structure.
      *
-     * @param null|ConfigInterface|ContainerInterface $configInstanceOrParentLocator
+     * @param null|ConfigInterface|ContainerInterface|PsrContainerInterface $configInstanceOrParentLocator
      * @param array $config
      */
     public function __construct($configInstanceOrParentLocator = null, array $config = [])

--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-servicemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ServiceManager;

--- a/src/PsrContainerDecorator.php
+++ b/src/PsrContainerDecorator.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager;
+
+use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * @internal for use in abstract plugin manager
+ */
+final class PsrContainerDecorator implements ContainerInterface
+{
+    /**
+     * @var PsrContainerInterface
+     */
+    private $container;
+
+    public function __construct(PsrContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Finds an entry of the container by its identifier and returns it.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
+     * @throws ContainerExceptionInterface Error while retrieving the entry.
+     *
+     * @return mixed Entry.
+     */
+    public function get($id)
+    {
+        return $this->container->get($id);
+    }
+
+    /**
+     * Returns true if the container can return an entry for the given identifier.
+     * Returns false otherwise.
+     *
+     * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
+     * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @return bool
+     */
+    public function has($id)
+    {
+        return $this->container->has($id);
+    }
+
+    /**
+     * @return PsrContainerInterface
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+}

--- a/src/PsrContainerDecorator.php
+++ b/src/PsrContainerDecorator.php
@@ -1,17 +1,14 @@
 <?php
-
 /**
- * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
- * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-servicemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ServiceManager;
 
 use Interop\Container\ContainerInterface;
-use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
-use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * @internal for use in abstract plugin manager
@@ -29,14 +26,7 @@ final class PsrContainerDecorator implements ContainerInterface
     }
 
     /**
-     * Finds an entry of the container by its identifier and returns it.
-     *
-     * @param string $id Identifier of the entry to look for.
-     *
-     * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
-     * @throws ContainerExceptionInterface Error while retrieving the entry.
-     *
-     * @return mixed Entry.
+     * {@inheritdoc}
      */
     public function get($id)
     {
@@ -44,15 +34,7 @@ final class PsrContainerDecorator implements ContainerInterface
     }
 
     /**
-     * Returns true if the container can return an entry for the given identifier.
-     * Returns false otherwise.
-     *
-     * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
-     * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
-     *
-     * @param string $id Identifier of the entry to look for.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function has($id)
     {

--- a/test/AbstractPluginManagerTest.php
+++ b/test/AbstractPluginManagerTest.php
@@ -9,7 +9,9 @@ namespace ZendTest\ServiceManager;
 
 use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
 use stdClass;
+use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ConfigInterface;
 use Zend\ServiceManager\Exception\InvalidArgumentException;
 use Zend\ServiceManager\Exception\InvalidServiceException;
@@ -17,6 +19,7 @@ use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\Factory\AbstractFactoryInterface;
 use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\Factory\InvokableFactory;
+use Zend\ServiceManager\PsrContainerDecorator;
 use Zend\ServiceManager\ServiceManager;
 use ZendTest\ServiceManager\TestAsset\InvokableObject;
 use ZendTest\ServiceManager\TestAsset\SimplePluginManager;
@@ -58,6 +61,32 @@ class AbstractPluginManagerTest extends TestCase
         $object = $pluginManager->get(InvokableObject::class);
 
         $this->assertInstanceOf(InvokableObject::class, $object);
+    }
+
+    public function testTransparentlyDecoratesNonInteropPsrContainerAsInteropContainer()
+    {
+        $invokableFactory = $this->getMockBuilder(FactoryInterface::class)
+            ->getMock();
+        $invokableFactory->method('__invoke')
+            ->will($this->returnArgument(0));
+
+        $config = [
+            'factories' => [
+                'creation context container' => $invokableFactory,
+            ],
+        ];
+
+        $container     = $this->getMockBuilder(PsrContainerInterface::class)
+            ->getMock();
+        $pluginManager = $this->getMockForAbstractClass(
+            AbstractPluginManager::class,
+            [$container, $config]
+        );
+
+        $object = $pluginManager->get('creation context container');
+
+        $this->assertInstanceOf(PsrContainerDecorator::class, $object);
+        $this->assertSame($container, $object->getContainer());
     }
 
     public function testValidateInstance()

--- a/test/PsrContainerDecoratorTest.php
+++ b/test/PsrContainerDecoratorTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
- * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-servicemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ServiceManager;

--- a/test/PsrContainerDecoratorTest.php
+++ b/test/PsrContainerDecoratorTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-servicemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager;
+
+use Psr\Container\ContainerInterface;
+use stdClass;
+use Zend\ServiceManager\PsrContainerDecorator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Zend\ServiceManager\PsrContainerDecorator
+ */
+class PsrContainerDecoratorTest extends TestCase
+{
+    public function testProxiesHasToDecoratedContainer()
+    {
+        $psrContainer = $this->getMockBuilder(ContainerInterface::class)
+            ->getMock();
+        $psrContainer->expects($this->exactly(2))
+            ->method('has')
+            ->with('string key')
+            ->willReturnOnConsecutiveCalls(true, false);
+        $decorator = new PsrContainerDecorator($psrContainer);
+        $this->assertTrue($decorator->has('string key'));
+        $this->assertFalse($decorator->has('string key'));
+    }
+
+    public function testProxiesGetToDecoratedContainer()
+    {
+        $service = new stdClass();
+        $psrContainer = $this->getMockBuilder(ContainerInterface::class)
+            ->getMock();
+        $psrContainer->expects($this->once())
+            ->method('get')
+            ->with('string key')
+            ->willReturn($service);
+        $decorator = new PsrContainerDecorator($psrContainer);
+        $this->assertSame($service, $decorator->get('string key'));
+    }
+
+    public function testGetterReturnsDecoratedContainer()
+    {
+        $psrContainer = $this->getMockBuilder(ContainerInterface::class)
+            ->getMock();
+        $decorator = new PsrContainerDecorator($psrContainer);
+        $this->assertSame($psrContainer, $decorator->getContainer());
+    }
+}


### PR DESCRIPTION
Enables plugin managers to accept non-interop psr containers as creation
context and transparently wrap as interop for backward compatibility

Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
    This PR enables plugin managers extending from abstract plugin manager to accept non-interop psr containers as creation context in a backward compatible manner. It is useful when alternative containers are used eg with zend-expressive.
    Decoration is necessary since FactoryInterface typehints against interop and won't work with pure PSR https://github.com/zendframework/zend-servicemanager/blob/0aea76faf40350852fd6570cb4c1eb60a18ac872/src/Factory/FactoryInterface.php#L10 https://github.com/zendframework/zend-servicemanager/blob/0aea76faf40350852fd6570cb4c1eb60a18ac872/src/Factory/FactoryInterface.php#L37
    This change is required since FactoryInterface typehints against interop container
  - [x] How will users use the new feature?
    Users now can pass non-interop psr containers as a constructor argument to plugin managers
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
    Unable as `develop` branch have changes targeted at next major release
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
    Change is internal, no documentation is needed.
  - [x] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
