### PR TITLE
Allow delegators to decorate the `$options` array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [PR] Adds the ability to decorate the `$options` array in delegator factories. 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- [PR] Adds the ability to decorate the `$options` array in delegator factories. 
+- [#276](https://github.com/zendframework/zend-servicemanager/pull/276) adds the ability 
+  to decorate the `$options` array in delegator factories.
 
 ### Changed
 

--- a/docs/book/delegators.md
+++ b/docs/book/delegators.md
@@ -31,6 +31,8 @@ The parameters passed to the delegator factory are the following:
 - `$name` is the name of the service being requested.
 - `$callback` is a [callable](http://www.php.net/manual/en/language.types.callable.php) that is
   responsible for instantiating the delegated service (the real service instance).
+  This callback accepts an optional `$options` array, that will replace the `$options` that were 
+  originally passed to the `ServiceManager`'s `build()` method.
 - `$options` is an array of options to use when creating the instance; these are
   typically used only during `build()` operations.
 


### PR DESCRIPTION
This PR allows delegator factories to decorate the `$options` array that is passed to the actual factory.

Use case:

```php

class MyService
{
    public function __construct(array $types)
    { /* ... */ }
}

$serviceConfig = [
    'factories' => [
        MyService::class => fuction($container, $name, $options) {
            return new MyService($options['types'] ?? []);
        }
    ],
    'delegators' => [
        MyService::class => [
            function($container, $name, $factory, $options) {
                $options['types'] = array_merge(
                    $options['types'] ?? [],
                    [ 'string' => 1 ]
                );
                $factory($options);
            },
        ],
    ],
]; 

```

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
  - [x] How will users use the new feature?
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [x] Add documentation for the new feature.
  - [x] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
